### PR TITLE
DM-33935: Create basic test framework for prompt-prototype

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -1,3 +1,26 @@
+# This file is part of prompt_prototype.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["check_for_snap", "next_visit_handler"]
+
 import base64
 import json
 import logging
@@ -9,8 +32,8 @@ from typing import Optional, Tuple
 from flask import Flask, request
 from google.cloud import pubsub_v1, storage
 
-from middleware_interface import MiddlewareInterface
-from visit import Visit
+from .middleware_interface import MiddlewareInterface
+from .visit import Visit
 
 PROJECT_ID = "prompt-proto"
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -68,7 +68,7 @@ class MiddlewareInterface:
         self.image_bucket = image_bucket
         self.instrument = instrument
 
-        self.repo = "/tmp/butler-{os.getpid()}"
+        self.repo = f"/tmp/butler-{os.getpid()}"
         if not os.path.exists(self.repo):
             _log.info(f"Making local Butler {self.repo}")
             Butler.makeRepo(self.repo)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1,3 +1,26 @@
+# This file is part of prompt_prototype.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["MiddlewareInterface"]
+
 import logging
 import os
 import shutil
@@ -5,7 +28,7 @@ import shutil
 from astropy.time import Time
 from lsst.daf.butler import Butler
 
-from visit import Visit
+from .visit import Visit
 
 PIPELINE_MAP = dict(
     BIAS="bias.yaml",

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -1,3 +1,5 @@
+__all__ = ["Visit"]
+
 from dataclasses import dataclass
 
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -44,7 +44,7 @@ def process_group(publisher, bucket, instrument, group, filter, kind):
         logging.info(f"Taking group {group} snap {snap}")
         time.sleep(EXPOSURE_INTERVAL)
         for detector in range(INSTRUMENTS[instrument].n_detectors):
-            logging.info(f"Uploading {group} {snap} {filter} {detector}")
+            logging.info(f"Uploading group: {group} snap: {snap} filter: {filter} detector: {detector}")
             exposure_id = (group // 100000) * 100000
             exposure_id += (group % 100000) * INSTRUMENTS[instrument].n_snaps
             exposure_id += snap

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -1,0 +1,72 @@
+# This file is part of prompt_prototype.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os.path
+import tempfile
+import unittest
+
+from activator.middleware_interface import MiddlewareInterface
+from activator.visit import Visit
+
+
+class MiddlewareInterfaceTest(unittest.TestCase):
+    def setUp(self):
+        input_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+        instrument = "TestCam"
+        self.output_dir = tempfile.TemporaryDirectory()
+        self.interface = MiddlewareInterface(input_dir, self.output_dir, instrument)
+        self.next_visit = Visit(instrument,
+                                detector=1,
+                                group=1,
+                                snaps=1,
+                                filter="r",
+                                ra=10,
+                                dec=20,
+                                kind="BIAS")
+        self.logger_name = "activator.middleware_interface"
+
+    def test_init(self):
+        """Basic tests of initializing an interface object.
+        """
+        # did we get a useable butler instance?
+        self.assertIn("/tmp/butler-", self.interface.dest.datastore.root.path)
+        # Ideas for things to test:
+        # * On init, does the right kind of butler get created, with the right
+        #   collections, etc?
+        # * On init, is the local butler repo purely in memory?
+
+    def test_prep_butler(self):
+        with self.assertLogs(self.logger_name, level="INFO") as cm:
+            self.interface.prep_butler(self.next_visit)
+        msg = f"INFO:{self.logger_name}:Preparing Butler for visit '{self.next_visit}'"
+        self.assertEqual(cm.output, [msg])
+
+    def test_ingest_image(self):
+        with self.assertLogs(self.logger_name, level="INFO") as cm:
+            self.interface.ingest_image(self.next_visit)
+        msg = f"INFO:{self.logger_name}:Ingesting image '{self.next_visit}'"
+        self.assertEqual(cm.output, [msg])
+
+    def test_run_pipeline(self):
+        with self.assertLogs(self.logger_name, level="INFO") as cm:
+            self.interface.run_pipeline(self.next_visit, 1)
+        msg = f"INFO:{self.logger_name}:Running pipeline bias.yaml on visit '{self.next_visit}', snaps 1"
+        self.assertEqual(cm.output, [msg])


### PR DESCRIPTION
This ended up being rather trivial; I'm putting this in review while I keep working on the flask/google.cloud tests (trying to mock a non-installed package (gcloud) is tricky). I'd rather have something to run in a github action now, while we figure out what we want the tests to actually do (I can't mock the butler interface until I have a better sense of how we'll actually use it).