### PR TITLE
DM-34018: Move activator service one level down.

### DIFF
--- a/python/activator/Dockerfile
+++ b/python/activator/Dockerfile
@@ -8,7 +8,7 @@ ARG CALIB_REPO
 ARG IMAGE_BUCKET
 ARG IMAGE_TIMEOUT
 WORKDIR $APP_HOME
-COPY . ./
+COPY . activator/
 CMD source /opt/lsst/software/stack/loadLSST.bash \
     && setup lsst_distrib \
-    && exec gunicorn --bind :$PORT --workers 1 --threads 1 --timeout 0 activator:app
+    && exec gunicorn --bind :$PORT --workers 1 --threads 1 --timeout 0 activator.activator:app


### PR DESCRIPTION
This should enable relative paths to work properly.