### PR TITLE
DM-33970: Use real images in upload.py

### DIFF
--- a/bin/prompt_prototype_upload_raws.sh
+++ b/bin/prompt_prototype_upload_raws.sh
@@ -33,6 +33,6 @@ UPLOAD_BUCKET=rubin-prompt-proto-unobserved
 # Filename format is defined in tester/upload.py and activator/activator.py:
 # instrument/detector/group/snap/instrument-group-snap-exposureId-filter-detector
 gsutil cp "${RAW_DIR}/HSC-0059150-050.fits.gz" \
-    gs://${UPLOAD_BUCKET}/HSC/50/2016030700001/0/HSC-2016030700001-0-0059150-HSC-G-050.fits.gz
+    gs://${UPLOAD_BUCKET}/HSC/50/2016030700001/0/HSC-2016030700001-0-0059150-HSC-G-50.fits.gz
 gsutil cp "${RAW_DIR}/HSC-0059160-051.fits.gz" \
-    gs://${UPLOAD_BUCKET}/HSC/51/2016030700002/0/HSC-2016030700002-0-0059160-HSC-G-051.fits.gz
+    gs://${UPLOAD_BUCKET}/HSC/51/2016030700002/0/HSC-2016030700002-0-0059160-HSC-G-51.fits.gz

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -3,7 +3,7 @@ __all__ = ["Visit"]
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Visit:
     instrument: str
     detector: int

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -233,12 +233,23 @@ def get_last_group(storage_client, instrument, date):
         The largest existing group for ``instrument``, or a newly generated
         group if none exist.
     """
-    blobs = storage_client.list_blobs(
+    preblobs = storage_client.list_blobs(
         "rubin-prompt-proto-main",
-        prefix=f"{instrument}/0/{date}",
+        prefix=f"{instrument}/",
         delimiter="/",
     )
-    # Contrary to the docs, blobs is not an iterator, but an iterable with a .prefixes member.
+    # See https://cloud.google.com/storage/docs/samples/storage-list-files-with-prefix
+    for blob in preblobs:
+        # Iterate over blobs to get past `list_blobs`'s pagination and
+        # fill .prefixes.
+        pass
+    detector = min(int(prefix.split("/")[1]) for prefix in preblobs.prefixes)
+
+    blobs = storage_client.list_blobs(
+        "rubin-prompt-proto-main",
+        prefix=f"{instrument}/{detector}/{date}",
+        delimiter="/",
+    )
     for blob in blobs:
         # Iterate over blobs to get past `list_blobs`'s pagination and
         # fill .prefixes.

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -51,9 +51,9 @@ _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
 
 
-def process_group(publisher, bucket, instrument, group, filter, kind):
+def process_group(publisher, bucket, instrument, group, filter, ra, dec, kind):
     n_snaps = INSTRUMENTS[instrument].n_snaps
-    send_next_visit(publisher, instrument, group, n_snaps, filter, kind)
+    send_next_visit(publisher, instrument, group, n_snaps, filter, ra, dec, kind)
     for snap in range(n_snaps):
         _log.info(f"Taking group: {group} snap: {snap}")
         time.sleep(EXPOSURE_INTERVAL)
@@ -65,11 +65,9 @@ def process_group(publisher, bucket, instrument, group, filter, kind):
             _log.info(f"Uploaded group: {group} snap: {snap} filter: {filter} detector: {detector}")
 
 
-def send_next_visit(publisher, instrument, group, snaps, filter, kind):
+def send_next_visit(publisher, instrument, group, snaps, filter, ra, dec, kind):
     _log.info(f"Sending next_visit for group: {group} snaps: {snaps} filter: {filter} kind: {kind}")
     topic_path = publisher.topic_path(PROJECT_ID, "nextVisit")
-    ra = random.uniform(0.0, 360.0)
-    dec = random.uniform(-90.0, 90.0)
     for detector in range(INSTRUMENTS[instrument].n_detectors):
         _log.debug(f"Sending next_visit for group: {group} detector: {detector} ra: {ra} dec: {dec}")
         visit = Visit(instrument, detector, group, snaps, filter, ra, dec, kind)
@@ -131,7 +129,9 @@ def main():
         kind = KINDS[i % len(KINDS)]
         group = last_group + i + 1
         filter = FILTER_LIST[random.randrange(0, len(FILTER_LIST))]
-        process_group(publisher, bucket, instrument, group, filter, kind)
+        ra = random.uniform(0.0, 360.0)
+        dec = random.uniform(-90.0, 90.0)
+        process_group(publisher, bucket, instrument, group, filter, ra, dec, kind)
         _log.info("Slewing to next group")
         time.sleep(SLEW_INTERVAL)
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -158,15 +158,8 @@ def main():
     _log.info(f"Last group {last_group}")
 
     for i in range(n_groups):
-        kind = KINDS[i % len(KINDS)]
         group = last_group + i + 1
-        filter = FILTER_LIST[random.randrange(0, len(FILTER_LIST))]
-        ra = random.uniform(0.0, 360.0)
-        dec = random.uniform(-90.0, 90.0)
-        visit_infos = {
-            Visit(instrument, detector, group, INSTRUMENTS[instrument].n_snaps, filter, ra, dec, kind)
-            for detector in range(INSTRUMENTS[instrument].n_detectors)
-        }
+        visit_infos = make_random_visits(instrument, group)
 
         # TODO: may be cleaner to use a functor object than to depend on
         # closures for the bucket and data.
@@ -213,6 +206,31 @@ def get_last_group(storage_client, instrument, date):
         return int(date) * 100_000
     else:
         return max(prefixes) + random.randrange(10, 19)
+
+
+def make_random_visits(instrument, group):
+    """Create placeholder visits without reference to any data.
+
+    Parameters
+    ----------
+    instrument : `str`
+        The short name of the instrument carrying out the observation.
+    group : `int`
+        The group number being observed.
+
+    Returns
+    -------
+    visits : `set` [`activator.Visit`]
+        Visits generated for ``group`` for all ``instrument``'s detectors.
+    """
+    kind = KINDS[group % len(KINDS)]
+    filter = FILTER_LIST[random.randrange(0, len(FILTER_LIST))]
+    ra = random.uniform(0.0, 360.0)
+    dec = random.uniform(-90.0, 90.0)
+    return {
+        Visit(instrument, detector, group, INSTRUMENTS[instrument].n_snaps, filter, ra, dec, kind)
+        for detector in range(INSTRUMENTS[instrument].n_detectors)
+    }
 
 
 if __name__ == "__main__":

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -85,6 +85,7 @@ def process_group(publisher, visit_infos, uploader):
         return
 
     send_next_visit(publisher, group, visit_infos)
+    # TODO: need asynchronous code to handle next_visit delay correctly
     for snap in range(n_snaps):
         _log.info(f"Taking group: {group} snap: {snap}")
         time.sleep(EXPOSURE_INTERVAL)

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -31,6 +31,18 @@ KINDS = ("BIAS", "DARK", "FLAT")
 PROJECT_ID = "prompt-proto"
 
 
+def raw_path(instrument, detector, group, snap, exposure_id, filter):
+    """The path on which to store raws in the raw bucket.
+
+    This format is also assumed by ``activator/activator.py.``
+    """
+    return (
+        f"{instrument}/{detector}/{group}/{snap}"
+        f"/{instrument}-{group}-{snap}"
+        f"-{exposure_id}-{filter}-{detector}.fz"
+    )
+
+
 logging.basicConfig(
     format="{levelname} {asctime} {name} - {message}",
     style="{",
@@ -48,11 +60,7 @@ def process_group(publisher, bucket, instrument, group, filter, kind):
         for detector in range(INSTRUMENTS[instrument].n_detectors):
             _log.info(f"Uploading group: {group} snap: {snap} filter: {filter} detector: {detector}")
             exposure_id = make_exposure_id(instrument, group, snap)
-            fname = (
-                f"{instrument}/{detector}/{group}/{snap}"
-                f"/{instrument}-{group}-{snap}"
-                f"-{exposure_id}-{filter}-{detector}.fz"
-            )
+            fname = raw_path(instrument, detector, group, snap, exposure_id, filter)
             bucket.blob(fname).upload_from_string("Test")
             _log.info(f"Uploaded group: {group} snap: {snap} filter: {filter} detector: {detector}")
 


### PR DESCRIPTION
This PR does a lot of refactoring of `upload.py` to make it easier to edit and more flexible with its inputs, then adds partial support for "observing" preloaded raw files. Because some of the raw metadata is hardcoded into the `get_samples` function, this script will break if any other raws are uploaded to `rubin-prompt-proto-unobserved`.

Because of the heavy refactoring on the first part of the ticket, I recommend reviewing this PR one or a few commits at a time; the net diff combines all the changes into one big rewrite.