### PR TITLE
DM-35053: Implement syncing of output products for Prompt Processing

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -1,4 +1,4 @@
-FROM lsstsqre/centos:w_latest
+FROM lsstsqre/centos:d_latest
 ENV PYTHONUNBUFFERED True
 RUN source /opt/lsst/software/stack/loadLSST.bash \
     && mamba install -y \

--- a/pipelines/calibrate.py
+++ b/pipelines/calibrate.py
@@ -6,10 +6,8 @@
 # band with the most depth).
 
 config.connections.astromRefCat = "gaia"
-config.astromRefObjLoader.ref_dataset_name = config.connections.astromRefCat
 config.astromRefObjLoader.anyFilterMapsToThis = "phot_g_mean"
 config.astromRefObjLoader.filterMap = {}
 
 # Use panstarrs for photometry (grizy filters).
 config.connections.photoRefCat = "panstarrs"
-config.photoRefObjLoader.ref_dataset_name = config.connections.photoRefCat

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -84,7 +84,7 @@ storage_client = storage.Client()
 # the central repo is located, either, so perhaps we need a new module.
 central_butler = Butler(calib_repo,
                         collections=[active_instrument.makeCollectionName("defaults")],
-                        writeable=False,
+                        writeable=True,
                         inferDefaults=False)
 repo = f"/tmp/butler-{os.getpid()}"
 butler = Butler(Butler.makeRepo(repo), writeable=True)

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -176,7 +176,7 @@ def next_visit_handler() -> Tuple[str, int]:
             )
             if oid:
                 m = re.match(RAW_REGEXP, oid)
-                mwi.ingest_image(oid)
+                mwi.ingest_image(expected_visit, oid)
                 expid_set.add(m.group('expid'))
 
         _log.debug(f"Waiting for snaps from {expected_visit}.")

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -227,6 +227,9 @@ def next_visit_handler() -> Tuple[str, int]:
                 _log.warning(f"Processing {len(expid_set)} snaps, expected {expected_visit.snaps}.")
             _log.info(f"Running pipeline on {expected_visit}.")
             mwi.run_pipeline(expected_visit, expid_set)
+            # TODO: broadcast alerts here
+            # TODO: call export_outputs on success or permanent failure in DM-34141
+            mwi.export_outputs(expected_visit, expid_set)
             return "Pipeline executed", 200
         else:
             _log.error(f"Timed out waiting for images for {expected_visit}.")

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -468,6 +468,12 @@ class MiddlewareInterface:
         #             'refcats'],
         #     output=self.output_collection)
         # The below is taken from SimplePipelineExecutor.prep_butler.
+        # TODO: currently the run **must** be unique for each unit of
+        # processing. It must be unique per group because in the prototype the
+        # same exposures may be rerun under different group IDs, and they must
+        # be unique per detector because the same worker may be tasked with
+        # different detectors from the same group. Replace with a single
+        # universal run on DM-36586.
         output_run = f"{self.output_collection}/{self.instrument.makeCollectionTimestamp()}"
         self.butler.registry.registerCollection(output_run, CollectionType.RUN)
         _prepend_collection(self.butler, self.output_collection, [output_run])

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -472,14 +472,14 @@ class MiddlewareInterface:
         assert len(result) == 1, "Should have ingested exactly one image."
         _log.info("Ingested one %s with dataId=%s", result[0].datasetType.name, result[0].dataId)
 
-    def run_pipeline(self, visit: Visit, exposure_ids: set) -> None:
+    def run_pipeline(self, visit: Visit, exposure_ids: set[int]) -> None:
         """Process the received image(s).
 
         Parameters
         ----------
         visit : Visit
             Group of snaps from one detector to be processed.
-        exposure_ids : `set`
+        exposure_ids : `set` [`int`]
             Identifiers of the exposures that were received.
         """
         # TODO: we want to define visits earlier, but we have to ingest a

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -292,11 +292,8 @@ class MiddlewareInterface:
         self.butler.registry.registerCollection(input_raws, CollectionType.RUN)
         _prepend_collection(self.butler, self.instrument.makeDefaultRawIngestRunName(), [input_raws])
 
-        # TODO: Until DM-35941, need to create a new butler to update governor
-        # dimensions; refresh isn't enough.
-        self.butler = Butler(butler=self.butler,
-                             collections=[self.output_collection],
-                             )
+        # Update for new collections, dimensions, and datasets.
+        self.butler.registry.refresh()
 
     def _export_refcats(self, export, center, radius):
         """Export the refcats for this visit from the central butler.

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -213,7 +213,7 @@ def make_random_visits(instrument, group):
     ----------
     instrument : `str`
         The short name of the instrument carrying out the observation.
-    group : `int`
+    group : `str`
         The group number being observed.
 
     Returns
@@ -344,7 +344,7 @@ def upload_from_raws(publisher, instrument, raw_pool, src_bucket, dest_bucket, n
                          "unobserved raws are available.")
 
     for i, true_group in enumerate(itertools.islice(raw_pool, n_groups)):
-        group = group_base + i
+        group = str(group_base + i)
         _log.debug(f"Processing group {group} from unobserved {true_group}...")
         # snap_dict maps snap_id to {visit: blob}
         snap_dict = {}
@@ -390,7 +390,7 @@ def upload_from_random(publisher, instrument, dest_bucket, n_groups, group_base)
         The base number from which to offset new group numbers.
     """
     for i in range(n_groups):
-        group = group_base + i
+        group = str(group_base + i)
         visit_infos = make_random_visits(instrument, group)
 
         # TODO: may be cleaner to use a functor object than to depend on

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+import dataclasses
 from google.cloud import pubsub_v1, storage
 from google.oauth2 import service_account
 import itertools
@@ -12,7 +12,7 @@ from activator.raw import RAW_REGEXP, get_raw_path
 from activator.visit import Visit
 
 
-@dataclass
+@dataclasses.dataclass
 class Instrument:
     n_snaps: int
     n_detectors: int
@@ -352,7 +352,7 @@ def upload_from_raws(publisher, instrument, raw_pool, src_bucket, dest_bucket, n
         # replacing the (immutable) Visit objects to point to group
         # instead of true_group.
         for snap_id, old_visits in raw_pool[true_group].items():
-            snap_dict[snap_id] = {splice_group(true_visit, group): blob
+            snap_dict[snap_id] = {dataclasses.replace(true_visit, group=group): blob
                                   for true_visit, blob in old_visits.items()}
         # Gather all the Visit objects found in snap_dict, merging
         # duplicates for different snaps of the same detector.
@@ -403,33 +403,6 @@ def upload_from_random(publisher, instrument, dest_bucket, n_groups, group_base)
         process_group(publisher, visit_infos, upload_dummy)
         _log.info("Slewing to next group")
         time.sleep(SLEW_INTERVAL)
-
-
-def splice_group(visit, group):
-    """Replace the group ID in a Visit object.
-
-    Parameters
-    ----------
-    visit : `activator.Visit`
-        The object to update.
-    group : `str`
-        The new group ID to use.
-
-    Returns
-    -------
-    new_visit : `activator.Visit`
-        A visit with group ``group``, but otherwise identical to ``visit``.
-    """
-    return Visit(instrument=visit.instrument,
-                 detector=visit.detector,
-                 group=group,
-                 snaps=visit.snaps,
-                 filter=visit.filter,
-                 ra=visit.ra,
-                 dec=visit.dec,
-                 rot=visit.rot,
-                 kind=visit.kind,
-                 )
 
 
 if __name__ == "__main__":

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import dataclasses
 import itertools
 import tempfile
 import os.path
@@ -236,31 +237,20 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.interface.prep_butler(self.next_visit)
 
         # Second visit with everything same except group.
-        self.next_visit = Visit(instrument=self.next_visit.instrument,
-                                detector=self.next_visit.detector,
-                                group=str(int(self.next_visit.group) + 1),
-                                snaps=self.next_visit.snaps,
-                                filter=self.next_visit.filter,
-                                ra=self.next_visit.ra,
-                                dec=self.next_visit.dec,
-                                rot=self.next_visit.rot,
-                                kind=self.next_visit.kind)
+        self.next_visit = dataclasses.replace(self.next_visit, group=str(int(self.next_visit.group) + 1))
         self.interface.prep_butler(self.next_visit)
         expected_shards = {157394, 157401, 157405}
         self._check_imports(self.butler, detector=56, expected_shards=expected_shards)
 
         # Third visit with different detector and coordinates.
         # Only 5, 10, 56, 60 have valid calibs.
-        self.next_visit = Visit(instrument=self.next_visit.instrument,
-                                detector=5,
-                                group=str(int(self.next_visit.group) + 1),
-                                snaps=self.next_visit.snaps,
-                                filter=self.next_visit.filter,
-                                # Offset by a bit over 1 patch.
-                                ra=self.next_visit.ra + 0.4,
-                                dec=self.next_visit.dec - 0.4,
-                                rot=self.next_visit.rot,
-                                kind=self.next_visit.kind)
+        self.next_visit = dataclasses.replace(self.next_visit,
+                                              detector=5,
+                                              group=str(int(self.next_visit.group) + 1),
+                                              # Offset by a bit over 1 patch.
+                                              ra=self.next_visit.ra + 0.4,
+                                              dec=self.next_visit.dec - 0.4,
+                                              )
         self.interface.prep_butler(self.next_visit)
         expected_shards.update({157218, 157229})
         self._check_imports(self.butler, detector=5, expected_shards=expected_shards)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -129,7 +129,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         rot = 90.
         self.next_visit = Visit(instrument_name,
                                 detector=56,
-                                group=1,
+                                group="1",
                                 snaps=1,
                                 filter=filter,
                                 ra=ra,
@@ -238,7 +238,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Second visit with everything same except group.
         self.next_visit = Visit(instrument=self.next_visit.instrument,
                                 detector=self.next_visit.detector,
-                                group=self.next_visit.group + 1,
+                                group=str(int(self.next_visit.group) + 1),
                                 snaps=self.next_visit.snaps,
                                 filter=self.next_visit.filter,
                                 ra=self.next_visit.ra,
@@ -253,7 +253,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Only 5, 10, 56, 60 have valid calibs.
         self.next_visit = Visit(instrument=self.next_visit.instrument,
                                 detector=5,
-                                group=self.next_visit.group + 1,
+                                group=str(int(self.next_visit.group) + 1),
                                 snaps=self.next_visit.snaps,
                                 filter=self.next_visit.filter,
                                 # Offset by a bit over 1 patch.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -155,6 +155,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that the butler instance is properly configured.
         instruments = list(self.butler.registry.queryDimensionRecords("instrument"))
         self.assertEqual(instname, instruments[0].name)
+        self.assertEqual(set(self.interface.butler.collections), {self.interface.output_collection})
 
         # Check that the ingester is properly configured.
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -256,6 +256,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     # This may be impossible to unit test, since it seems to depend on Google-side parallelism.
 
     def test_ingest_image(self):
+        self.interface.prep_butler(self.next_visit)  # Ensure raw collections exist.
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = fake_file_data(filepath,
@@ -264,7 +265,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(filename)
+            self.interface.ingest_image(self.next_visit, filename)
 
             datasets = list(self.butler.registry.queryDatasets('raw',
                                                                collections=[f'{instname}/raw/all']))
@@ -283,6 +284,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         through ingest_image(), we'll want to have a test of "missing file
         ingestion", and this can serve as a starting point.
         """
+        self.interface.prep_butler(self.next_visit)  # Ensure raw collections exist.
         filename = "nonexistentImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = fake_file_data(filepath,
@@ -292,7 +294,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock, \
                 self.assertRaisesRegex(FileNotFoundError, "Resource at .* does not exist"):
             mock.return_value = file_data
-            self.interface.ingest_image(filename)
+            self.interface.ingest_image(self.next_visit, filename)
         # There should not be any raw files in the registry.
         datasets = list(self.butler.registry.queryDatasets('raw',
                                                            collections=[f'{instname}/raw/all']))
@@ -313,7 +315,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(filename)
+            self.interface.ingest_image(self.next_visit, filename)
 
         with unittest.mock.patch("activator.middleware_interface.SimplePipelineExecutor.run") as mock_run:
             with self.assertLogs(self.logger_name, level="INFO") as logs:
@@ -337,7 +339,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(filename)
+            self.interface.ingest_image(self.next_visit, filename)
 
         with self.assertRaisesRegex(RuntimeError, "No data to process"):
             self.interface.run_pipeline(self.next_visit, {2})


### PR DESCRIPTION
This PR adds a "merge to central repo" operation to the activator. Because of technical limitations, this operation currently transfers visit-detector level datasets, but not single-ID datasets like task configs or catalog schemas. This limitation will need to be addressed later.

In addition, this PR carries out a large amount of refactoring that was needed to implement and/or debug the primary feature:
- changes to how raws and output datasets are organized into runs, to avoid collisions in the central repo.
- fixes to the construction of `Visit` objects, simplifying code and fixing an untestable type error.
- reorganizing the internal state of `MiddlewareInterface` so that all of it is either a) "persistent" state that is established at class construction, or b) visit-specific state that is local to the methods that work on that visit. This makes the behavior of its methods more predictable (less state-dependent), keeps old runs from "leaking" into new ones, and makes the class as a whole easier to reason about.
- documenting class invariants, preconditions, and postconditions in preparation for future work towards making the class more robust.