### PR TITLE
DM-35941: Remove use of implicit dimensions in Prompt Prototype

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -84,13 +84,9 @@ storage_client = storage.Client()
 # However, we don't want MiddlewareInterface to need to know details like where
 # the central repo is located, either, so perhaps we need a new module.
 central_butler = Butler(calib_repo,
-                        instrument=active_instrument.getName(),
-                        # NOTE: with inferDefaults=True, it's possible we don't need to hardcode this
-                        #     value from the real repository.
-                        # skymap="hsc_rings_v1",
                         collections=[active_instrument.makeCollectionName("defaults")],
                         writeable=False,
-                        inferDefaults=True)
+                        inferDefaults=False)
 repo = f"/tmp/butler-{os.getpid()}"
 butler = Butler(Butler.makeRepo(repo), writeable=True)
 _log.info("Created local Butler repo at %s.", repo)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -524,6 +524,7 @@ def _query_missing_datasets(src_repo: Butler, dest_repo: Butler,
     *args, **kwargs
         Parameters for describing the dataset query. They have the same
         meanings as the parameters of `lsst.daf.butler.Registry.queryDatasets`.
+        The query must be valid for both ``src_repo`` and ``dest_repo``.
 
     Returns
     -------

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -244,9 +244,8 @@ class MiddlewareInterface:
             Radius to search for refcat shards in.
         """
         indexer = HtmIndexer(depth=7)
-        shards = indexer.getShardIds(center, radius+self.padding)
-        # getShardIds returns a tuple, the first item is the ids list.
-        htm_where = f"htm7 in ({','.join(str(x) for x in shards[0])})"
+        shard_ids, _ = indexer.getShardIds(center, radius+self.padding)
+        htm_where = f"htm7 in ({','.join(str(x) for x in shard_ids)})"
         # Get shards from all refcats that overlap this detector.
         # TODO: `...` doesn't work for this queryDatasets call
         # currently, and we can't queryDatasetTypes in just the refcats

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -6,11 +6,11 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Visit:
     # elements must be hashable and JSON-persistable; built-in types recommended
-    instrument: str
+    instrument: str    # short name
     detector: int
-    group: str
-    snaps: int
-    filter: str
+    group: str         # observatory-specific ID; not the same as visit number
+    snaps: int         # number of snaps expected
+    filter: str        # physical filter
     # all angles are in degrees
     ra: float
     dec: float

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -170,7 +170,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that the right skymap is in the chained output collection.
         self.assertTrue(
             butler.datasetExists("skyMap",
-                                 # TODO: we shouldn't need skymap here?
                                  skymap="deepCoadd_skyMap",
                                  collections=self.interface.output_collection)
         )
@@ -209,7 +208,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         butler.registry.refresh()
         for patch in (464, 465, 509, 510):
             butler.datasetExists('deepCoadd', tract=0, patch=patch, band="g",
-                                 # TODO: we shouldn't need skymap here?
                                  skymap="deepCoadd_skyMap",
                                  collections=self.interface.output_collection)
 

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -115,6 +115,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                 collections=[f"{instname}/defaults"],
                                 writeable=False)
         instrument = "lsst.obs.decam.DarkEnergyCamera"
+        instrument_name = "DECam"
         self.input_data = os.path.join(data_dir, "input_data")
         # Have to preserve the tempdir, so that it doesn't get cleaned up.
         self.repo = tempfile.TemporaryDirectory()
@@ -127,7 +128,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         dec = -4.950050405424033
         # DECam has no rotator; instrument angle is 90 degrees in our system.
         rot = 90.
-        self.next_visit = Visit(instrument,
+        self.next_visit = Visit(instrument_name,
                                 detector=56,
                                 group=1,
                                 snaps=1,

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -110,10 +110,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         central_repo = os.path.join(data_dir, "central_repo")
         central_butler = Butler(central_repo,
-                                instrument=instname,
-                                skymap="deepCoadd_skyMap",
                                 collections=[f"{instname}/defaults"],
-                                writeable=False)
+                                writeable=False,
+                                inferDefaults=False)
         instrument = "lsst.obs.decam.DarkEnergyCamera"
         instrument_name = "DECam"
         self.input_data = os.path.join(data_dir, "input_data")


### PR DESCRIPTION
This PR adds explicit `instrument` and `skymap` dimensions to all Butler queries, and removes code that the use of default dimensions had made necessary. The result is much more likely to behave consistently in different conditions, increasing the value and relevance of the existing unit tests. The first few commits fix some smaller bugs discovered while examining the code or testing the explicit dimensions.

This PR depends on, and cannot be merged before, #24.