### PR TITLE
DM-34020: Get Google Cloud to detect logging levels in prompt_prototype

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -34,6 +34,7 @@ from google.cloud import pubsub_v1, storage
 
 from lsst.daf.butler import Butler
 from lsst.obs.base import Instrument
+from .logger import GCloudStructuredLogFormatter
 from .make_pgpass import make_pgpass
 from .middleware_interface import MiddlewareInterface
 from .raw import RAW_REGEXP
@@ -49,15 +50,14 @@ calib_repo = os.environ["CALIB_REPO"]
 image_bucket = os.environ["IMAGE_BUCKET"]
 timeout = os.environ.get("IMAGE_TIMEOUT", 50)
 
-logging.basicConfig(
-    # Use JSON format compatible with Google Cloud Logging
-    format=(
-        '{{"severity":"{levelname}", "labels":{{"instrument":"'
-        + active_instrument.getName()
-        + '"}}, "message":{message!r}}}'
-    ),
-    style="{",
-)
+# Set up logging for all modules used by this worker.
+log_handler = logging.StreamHandler()
+log_handler.setFormatter(GCloudStructuredLogFormatter(
+    '{{"severity":"{levelname}", "labels":{{"instrument":"'
+    + active_instrument.getName()
+    + '"}}, "message":{message!r}}}'
+))
+logging.basicConfig(handlers=[log_handler])
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -229,7 +229,7 @@ def next_visit_handler() -> Tuple[str, int]:
             mwi.run_pipeline(expected_visit, expid_set)
             return "Pipeline executed", 200
         else:
-            _log.fatal(f"Timed out waiting for images for {expected_visit}.")
+            _log.error(f"Timed out waiting for images for {expected_visit}.")
             return "Timed out waiting for images", 500
     finally:
         subscriber.delete_subscription(subscription=subscription.name)

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -53,9 +53,6 @@ timeout = os.environ.get("IMAGE_TIMEOUT", 50)
 # Set up logging for all modules used by this worker.
 log_handler = logging.StreamHandler()
 log_handler.setFormatter(GCloudStructuredLogFormatter(
-    '{{"severity":"{levelname}", "labels":{{"instrument":"'
-    + active_instrument.getName()
-    + '"}}, "message":{message!r}}}',
     labels={"instrument": active_instrument.getName()},
 ))
 logging.basicConfig(handlers=[log_handler])

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -55,7 +55,8 @@ log_handler = logging.StreamHandler()
 log_handler.setFormatter(GCloudStructuredLogFormatter(
     '{{"severity":"{levelname}", "labels":{{"instrument":"'
     + active_instrument.getName()
-    + '"}}, "message":{message!r}}}'
+    + '"}}, "message":{message!r}}}',
+    labels={"instrument": active_instrument.getName()},
 ))
 logging.basicConfig(handlers=[log_handler])
 _log = logging.getLogger("lsst." + __name__)

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -58,6 +58,7 @@ log_handler.setFormatter(GCloudStructuredLogFormatter(
 logging.basicConfig(handlers=[log_handler])
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
+logging.captureWarnings(True)
 
 
 # Write PostgreSQL credentials.

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -1,0 +1,39 @@
+# This file is part of prompt_prototype.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["GCloudStructuredLogFormatter"]
+
+import logging
+
+
+class GCloudStructuredLogFormatter(logging.Formatter):
+    """A formatter that can be parsed by the Google Cloud logging agent.
+
+    The formatter's output is a JSON-encoded message containing keywords
+    recognized by the logging agent.
+
+    Parameters
+    ----------
+    fmt : `str`
+        A log output format string compatible with `str.format`.
+    """
+    def __init__(self, fmt=None):
+        super().__init__(fmt=fmt, style="{")

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -21,6 +21,7 @@
 
 __all__ = ["GCloudStructuredLogFormatter"]
 
+import json
 import logging
 
 
@@ -45,3 +46,14 @@ class GCloudStructuredLogFormatter(logging.Formatter):
             self._labels = labels
         else:
             self._labels = {}
+
+    def format(self, record):
+        # Call for side effects only; ignore result.
+        super().format(record)
+
+        entry = {
+            "severity": record.levelname,
+            "labels": self._labels,
+            "message": record.getMessage(),
+        }
+        return json.dumps(entry)

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -51,7 +51,7 @@ class GCloudStructuredLogFormatter(logging.Formatter):
 
         entry = {
             "severity": record.levelname,
-            "labels": self._labels,
+            "logging.googleapis.com/labels": self._labels,
             "message": record.getMessage(),
         }
         return json.dumps(entry)

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -33,14 +33,12 @@ class GCloudStructuredLogFormatter(logging.Formatter):
 
     Parameters
     ----------
-    fmt : `str`
-        A log output format string compatible with `str.format`.
     labels : `dict` [`str`, `str`]
         Any metadata that should be attached to the log. See ``LogEntry.labels``
         in Google Cloud REST API documentation.
     """
-    def __init__(self, fmt=None, labels=None):
-        super().__init__(fmt=fmt, style="{")
+    def __init__(self, labels=None):
+        super().__init__()
 
         if labels:
             self._labels = labels

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -34,6 +34,14 @@ class GCloudStructuredLogFormatter(logging.Formatter):
     ----------
     fmt : `str`
         A log output format string compatible with `str.format`.
+    labels : `dict` [`str`, `str`]
+        Any metadata that should be attached to the log. See ``LogEntry.labels``
+        in Google Cloud REST API documentation.
     """
-    def __init__(self, fmt=None):
+    def __init__(self, fmt=None, labels=None):
         super().__init__(fmt=fmt, style="{")
+
+        if labels:
+            self._labels = labels
+        else:
+            self._labels = {}

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -48,7 +48,6 @@ class GoogleFormatterTest(unittest.TestCase):
 
         log_handler = logging.StreamHandler(self.output)
         log_handler.setFormatter(GCloudStructuredLogFormatter(
-            '{{"severity":"{levelname}", "labels":{{"instrument":"NotACam"}}, "message":{message!r}}}',
             labels={"instrument": "NotACam"},
         ))
         # Unique logger per test

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -75,7 +75,7 @@ class GoogleFormatterTest(unittest.TestCase):
             parsed = json.loads(output)
             self.assertEqual(parsed["severity"], level)
             self.assertEqual(parsed["message"], text)
-            self.assertEqual(parsed["labels"], labels)
+            self.assertEqual(parsed["logging.googleapis.com/labels"], labels)
 
     def test_direct(self):
         """Test the translation of verbatim log messages.

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -49,6 +49,7 @@ class GoogleFormatterTest(unittest.TestCase):
         log_handler = logging.StreamHandler(self.output)
         log_handler.setFormatter(GCloudStructuredLogFormatter(
             '{{"severity":"{levelname}", "labels":{{"instrument":"NotACam"}}, "message":{message!r}}}',
+            labels={"instrument": "NotACam"},
         ))
         # Unique logger per test
         self.log = logging.getLogger(self.id())

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,93 @@
+# This file is part of prompt_prototype.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import io
+import logging
+import re
+import unittest
+
+from activator.logger import GCloudStructuredLogFormatter
+
+
+class GoogleFormatterTest(unittest.TestCase):
+    """Test GCloudStructuredLogFormatter with fake log messages.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Each test has its own handler
+        # logging.basicConfig(handlers=[logging.NullHandler()])
+
+    def setUp(self):
+        super().setUp()
+
+        # Buffer for log output.
+        # Can't use assertLogs, because it inserts its own handler/formatter.
+        self.output = io.StringIO()
+        self.addCleanup(io.StringIO.close, self.output)
+
+        log_handler = logging.StreamHandler(self.output)
+        log_handler.setFormatter(GCloudStructuredLogFormatter(
+            '{{"severity":"{levelname}", "labels":{{"instrument":"NotACam"}}, "message":{message!r}}}',
+        ))
+        # Unique logger per test
+        self.log = logging.getLogger(self.id())
+        self.log.propagate = False
+        self.log.addHandler(log_handler)
+        self.log.setLevel(logging.DEBUG)
+
+    def _check_log(self, outputs, level, texts):
+        """Check that the log output is formatted correctly.
+
+        Parameters
+        ----------
+        outputs : `list` [`str`]
+            A list of the formatted log messages.
+        level : `str`
+            The emitted log level.
+        texts : `list` [`str`]
+            The expected log messages.
+        """
+        self.assertEqual(len(outputs), len(texts))
+        for output, text in zip(outputs, texts):
+            # Make all whitespace optional
+            expected = re.compile('{"severity": *"%s", *' % level
+                                  + '"labels": *{"instrument": *"NotACam"}, *'
+                                  + '"message": *\'%s\'}' % re.escape(text)
+                                  )
+            self.assertRegex(output, expected)
+
+    def test_direct(self):
+        """Test the translation of verbatim log messages.
+        """
+        msg = "Consider a spherical cow..."
+        self.log.info(msg)
+        self._check_log(self.output.getvalue().splitlines(), "INFO", [msg])
+
+    def test_args(self):
+        """Test the translation of arg-based log messages.
+        """
+        msg = "Consider a %s..."
+        args = "rotund bovine"
+        self.log.warning(msg, args)
+        self._check_log(self.output.getvalue().splitlines(), "WARNING", [msg % args])


### PR DESCRIPTION
This PR fixes several bugs that together prevented some Prompt Processing logs from being correctly parsed by Google Cloud. In the process, it factors out the existing logging setup into a form that will be easier to expand later (e.g., with more context-specific information).

With these changes, the only output that is still unparsed is that from Google infrastructure itself (e.g., worker startup/shutdown) and the "Overriding default configuration file with [path]/config/.dustmapsrc" message, which appears to be sent directly to standard output.