### PR TITLE
DM-36080: Separate GCP-specific code in Prompt Processing prototype

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -108,11 +108,15 @@ To create or edit the Cloud Run service in the Google Cloud Console:
   * CALIB_REPO: URI to repo containing calibrations (and templates)
   * IP_APDB: IP address and port of the APDB (see `Databases`_, below)
   * IP_REGISTRY: IP address and port of the registry database (see `Databases`_)
+  * DB_APDB: PostgreSQL database name for the APDB
+  * DB_REGISTRY: PostgreSQL database name for the registry database
 
-* There are also two optional parameters:
+* There are also four optional parameters:
 
   * IMAGE_TIMEOUT: timeout in seconds to wait for raw image, default 50 sec.
   * LOCAL_REPOS: absolute path (in the container) where local repos are created, default ``/tmp``.
+  * USER_APDB: database user for the APDB, default "postgres"
+  * USER_REGISTRY: database user for the registry database, default "postgres"
 
 * One variable is set by Cloud Run and should not be overridden:
 

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -102,7 +102,7 @@ To create or edit the Cloud Run service in the Google Cloud Console:
 * Select the container image URL from "Artifact Registry > prompt-proto-service"
 * In the Variables & Secrets tab, set the following required parameters:
 
-  * RUBIN_INSTRUMENT: full instrument class name, including module path
+  * RUBIN_INSTRUMENT: the "short" instrument name
   * PUBSUB_VERIFICATION_TOKEN: choose an arbitrary string matching the Pub/Sub endpoint URL below
   * IMAGE_BUCKET: bucket containing raw images (``rubin-prompt-proto-main``)
   * CALIB_REPO: repo containing calibrations (and templates)

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -105,7 +105,7 @@ To create or edit the Cloud Run service in the Google Cloud Console:
   * RUBIN_INSTRUMENT: the "short" instrument name
   * PUBSUB_VERIFICATION_TOKEN: choose an arbitrary string matching the Pub/Sub endpoint URL below
   * IMAGE_BUCKET: bucket containing raw images (``rubin-prompt-proto-main``)
-  * CALIB_REPO: repo containing calibrations (and templates)
+  * CALIB_REPO: URI to repo containing calibrations (and templates)
   * IP_APDB: IP address and port of the APDB (see `Databases`_, below)
   * IP_REGISTRY: IP address and port of the registry database (see `Databases`_)
 

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -117,6 +117,7 @@ To create or edit the Cloud Run service in the Google Cloud Console:
   * LOCAL_REPOS: absolute path (in the container) where local repos are created, default ``/tmp``.
   * USER_APDB: database user for the APDB, default "postgres"
   * USER_REGISTRY: database user for the registry database, default "postgres"
+  * NAMESPACE_APDB: the database namespace for the APDB, defaults to the DB's default namespace
 
 * One variable is set by Cloud Run and should not be overridden:
 

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -109,9 +109,10 @@ To create or edit the Cloud Run service in the Google Cloud Console:
   * IP_APDB: IP address and port of the APDB (see `Databases`_, below)
   * IP_REGISTRY: IP address and port of the registry database (see `Databases`_)
 
-* There is also one optional parameter:
+* There are also two optional parameters:
 
   * IMAGE_TIMEOUT: timeout in seconds to wait for raw image, default 50 sec.
+  * LOCAL_REPOS: absolute path (in the container) where local repos are created, default ``/tmp``.
 
 * One variable is set by Cloud Run and should not be overridden:
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -185,6 +185,7 @@ def next_visit_handler() -> Tuple[str, int]:
             )
             if oid:
                 raw_info = Snap.from_oid(oid)
+                _log.debug("Found %r already present", raw_info)
                 mwi.ingest_image(expected_visit, oid)
                 expid_set.add(raw_info.exp_id)
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -44,14 +44,14 @@ PROJECT_ID = "prompt-proto"
 verification_token = os.environ["PUBSUB_VERIFICATION_TOKEN"]
 # The full instrument class name, including module path.
 config_instrument = os.environ["RUBIN_INSTRUMENT"]
-active_instrument = Instrument.from_string(config_instrument)
+instrument_name = Instrument.from_string(config_instrument).getName()
 calib_repo = os.environ["CALIB_REPO"]
 image_bucket = os.environ["IMAGE_BUCKET"]
 timeout = os.environ.get("IMAGE_TIMEOUT", 50)
 local_repos = os.environ.get("LOCAL_REPOS", "/tmp")
 
 setup_google_logger(
-    labels={"instrument": active_instrument.getName()},
+    labels={"instrument": instrument_name},
 )
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
@@ -67,7 +67,7 @@ app = Flask(__name__)
 subscriber = pubsub_v1.SubscriberClient()
 topic_path = subscriber.topic_path(
     PROJECT_ID,
-    f"{active_instrument.getName()}-image",
+    f"{instrument_name}-image",
 )
 subscription = None
 
@@ -147,8 +147,8 @@ def next_visit_handler() -> Tuple[str, int]:
         payload = base64.b64decode(envelope["message"]["data"])
         data = json.loads(payload)
         expected_visit = Visit(**data)
-        assert expected_visit.instrument == active_instrument.getName(), \
-            f"Expected {active_instrument.getName()}, received {expected_visit.instrument}."
+        assert expected_visit.instrument == instrument_name, \
+            f"Expected {instrument_name}, received {expected_visit.instrument}."
         expid_set = set()
 
         # Copy calibrations for this detector/visit

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -49,6 +49,7 @@ active_instrument = Instrument.from_string(config_instrument)
 calib_repo = os.environ["CALIB_REPO"]
 image_bucket = os.environ["IMAGE_BUCKET"]
 timeout = os.environ.get("IMAGE_TIMEOUT", 50)
+local_repos = os.environ.get("LOCAL_REPOS", "/tmp")
 
 setup_google_logger(
     labels={"instrument": active_instrument.getName()},
@@ -82,7 +83,7 @@ central_butler = Butler(calib_repo,
                         collections=[active_instrument.makeCollectionName("defaults")],
                         writeable=True,
                         inferDefaults=False)
-repo = f"/tmp/butler-{os.getpid()}"
+repo = os.path.join(local_repos, f"butler-{os.getpid()}")
 butler = Butler(Butler.makeRepo(repo), writeable=True)
 _log.info("Created local Butler repo at %s.", repo)
 mwi = MiddlewareInterface(central_butler, image_bucket, config_instrument, butler)

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -214,12 +214,7 @@ def next_visit_handler() -> Tuple[str, int]:
                 try:
                     raw_info = Snap.from_oid(oid)
                     _log.debug("Received %r", raw_info)
-                    if (
-                        raw_info.instrument == expected_visit.instrument
-                        and raw_info.detector == int(expected_visit.detector)
-                        and raw_info.group == str(expected_visit.group)
-                        and raw_info.snap < int(expected_visit.snaps)
-                    ):
+                    if raw_info.is_consistent(expected_visit):
                         # Ingest the snap
                         mwi.ingest_image(oid)
                         expid_set.add(raw_info.exp_id)

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -34,7 +34,7 @@ from google.cloud import pubsub_v1, storage
 
 from lsst.daf.butler import Butler
 from lsst.obs.base import Instrument
-from .logger import GCloudStructuredLogFormatter
+from .logger import setup_google_logger
 from .make_pgpass import make_pgpass
 from .middleware_interface import MiddlewareInterface
 from .raw import RAW_REGEXP
@@ -50,15 +50,11 @@ calib_repo = os.environ["CALIB_REPO"]
 image_bucket = os.environ["IMAGE_BUCKET"]
 timeout = os.environ.get("IMAGE_TIMEOUT", 50)
 
-# Set up logging for all modules used by this worker.
-log_handler = logging.StreamHandler()
-log_handler.setFormatter(GCloudStructuredLogFormatter(
+setup_google_logger(
     labels={"instrument": active_instrument.getName()},
-))
-logging.basicConfig(handlers=[log_handler])
+)
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
-logging.captureWarnings(True)
 
 
 # Write PostgreSQL credentials.

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -43,9 +43,13 @@ PROJECT_ID = "prompt-proto"
 verification_token = os.environ["PUBSUB_VERIFICATION_TOKEN"]
 # The short name for the instrument.
 instrument_name = os.environ["RUBIN_INSTRUMENT"]
+# URI to the main repository containing calibs and templates
 calib_repo = os.environ["CALIB_REPO"]
+# Bucket name (not URI) containing raw images
 image_bucket = os.environ["IMAGE_BUCKET"]
+# Time to wait for raw image upload, in seconds
 timeout = os.environ.get("IMAGE_TIMEOUT", 50)
+# Absolute path on this worker's system where local repos may be created
 local_repos = os.environ.get("LOCAL_REPOS", "/tmp")
 
 setup_google_logger(

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -32,7 +32,6 @@ from typing import Optional, Tuple
 from flask import Flask, request
 from google.cloud import pubsub_v1, storage
 
-from lsst.obs.base import Instrument
 from .logger import setup_google_logger
 from .make_pgpass import make_pgpass
 from .middleware_interface import get_central_butler, MiddlewareInterface
@@ -42,9 +41,8 @@ from .visit import Visit
 PROJECT_ID = "prompt-proto"
 
 verification_token = os.environ["PUBSUB_VERIFICATION_TOKEN"]
-# The full instrument class name, including module path.
-config_instrument = os.environ["RUBIN_INSTRUMENT"]
-instrument_name = Instrument.from_string(config_instrument).getName()
+# The short name for the instrument.
+instrument_name = os.environ["RUBIN_INSTRUMENT"]
 calib_repo = os.environ["CALIB_REPO"]
 image_bucket = os.environ["IMAGE_BUCKET"]
 timeout = os.environ.get("IMAGE_TIMEOUT", 50)
@@ -74,9 +72,9 @@ subscription = None
 storage_client = storage.Client()
 
 # Initialize middleware interface.
-mwi = MiddlewareInterface(get_central_butler(calib_repo, config_instrument),
+mwi = MiddlewareInterface(get_central_butler(calib_repo, instrument_name),
                           image_bucket,
-                          config_instrument,
+                          instrument_name,
                           local_repos)
 
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -83,10 +83,7 @@ central_butler = Butler(calib_repo,
                         collections=[active_instrument.makeCollectionName("defaults")],
                         writeable=True,
                         inferDefaults=False)
-repo = os.path.join(local_repos, f"butler-{os.getpid()}")
-butler = Butler(Butler.makeRepo(repo), writeable=True)
-_log.info("Created local Butler repo at %s.", repo)
-mwi = MiddlewareInterface(central_butler, image_bucket, config_instrument, butler)
+mwi = MiddlewareInterface(central_butler, image_bucket, config_instrument, local_repos)
 
 
 def check_for_snap(

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -19,10 +19,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["GCloudStructuredLogFormatter"]
+__all__ = ["GCloudStructuredLogFormatter", "setup_google_logger"]
 
 import json
 import logging
+
+
+# TODO: replace with something more extensible, once we know what needs to
+# vary besides the formatter (handler type?).
+def setup_google_logger(labels=None):
+    """Set global logging settings for prompt_prototype.
+
+    Calling this function makes `GCloudStructuredLogFormatter` the root
+    formatter and redirects all warnings to go through it.
+
+    Parameters
+    ----------
+    labels : `dict` [`str`, `str`]
+        Any metadata that should be attached to all logs. See
+        ``LogEntry.labels`` in Google Cloud REST API documentation.
+
+    Returns
+    -------
+    handler : `logging.Handler`
+        The handler used by the root logger.
+    """
+    log_handler = logging.StreamHandler()
+    log_handler.setFormatter(GCloudStructuredLogFormatter(labels))
+    logging.basicConfig(handlers=[log_handler])
+    logging.captureWarnings(True)
+    return log_handler
 
 
 class GCloudStructuredLogFormatter(logging.Formatter):

--- a/python/activator/make_pgpass.py
+++ b/python/activator/make_pgpass.py
@@ -27,7 +27,6 @@ import os
 import stat
 
 
-PSQL_DB = "postgres"
 PSQL_USER = "postgres"
 
 
@@ -44,15 +43,19 @@ def make_pgpass():
     """
     try:
         ip_apdb = os.environ["IP_APDB"]
+        db_apdb = os.environ["DB_APDB"]
+        user_apdb = os.environ.get("USER_APDB", PSQL_USER)
         pass_apdb = os.environ["PSQL_APDB_PASS"]
         ip_registry = os.environ["IP_REGISTRY"]
+        db_registry = os.environ["DB_REGISTRY"]
+        user_registry = os.environ.get("USER_REGISTRY", PSQL_USER)
         pass_registry = os.environ["PSQL_REGISTRY_PASS"]
     except KeyError as e:
         raise RuntimeError("Addresses and passwords have not been configured") from e
 
     filename = os.path.join(os.environ["HOME"], ".pgpass")
     with open(filename, mode="wt") as file:
-        file.write(f"{ip_apdb}:{PSQL_DB}:{PSQL_USER}:{pass_apdb}\n")
-        file.write(f"{ip_registry}:{PSQL_DB}:{PSQL_USER}:{pass_registry}\n")
+        file.write(f"{ip_apdb}:{db_apdb}:{user_apdb}:{pass_apdb}\n")
+        file.write(f"{ip_registry}:{db_registry}:{user_registry}:{pass_registry}\n")
     # Only user may access the file
     os.chmod(filename, stat.S_IRUSR)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -139,7 +139,10 @@ class MiddlewareInterface:
     def __init__(self, central_butler: Butler, image_bucket: str, instrument: str,
                  local_storage: str,
                  prefix: str = "gs://"):
+        # TODO: merge this code with make_pgpass.py
         self.ip_apdb = os.environ["IP_APDB"]
+        self.db_apdb = os.environ["DB_APDB"]
+        self.user_apdb = os.environ.get("USER_APDB", "postgres")
         self.central_butler = central_butler
         self.image_host = prefix + image_bucket
         # TODO: _download_store turns MWI into a tagged class; clean this up later
@@ -536,10 +539,9 @@ class MiddlewareInterface:
             pipeline = lsst.pipe.base.Pipeline.fromFile(ap_pipeline_file)
         except FileNotFoundError:
             raise RuntimeError(f"No ApPipe.yaml defined for camera {self.instrument.getName()}")
-        # TODO: Can we write to a configurable apdb schema, rather than
-        # "postgres"?
+        # TODO: Can we write to a configurable apdb schema?
         pipeline.addConfigOverride("diaPipe", "apdb.db_url",
-                                   f"postgresql://postgres@{self.ip_apdb}/postgres")
+                                   f"postgresql://{self.user_apdb}@{self.ip_apdb}/{self.db_apdb}")
         return pipeline
 
     def _download(self, remote):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["MiddlewareInterface"]
+__all__ = ["get_central_butler", "MiddlewareInterface"]
 
 import collections.abc
 import itertools
@@ -43,6 +43,32 @@ from .visit import Visit
 
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
+
+
+def get_central_butler(central_repo: str, instrument_class: str):
+    """Provide a Butler that can access the given repository and read and write
+    data for the given instrument.
+
+    Parameters
+    ----------
+    central_repo : `str`
+        The path or URI to the central repository.
+    instrument_class : `str`
+        The fully-qualified class name of the instrument whose data will be
+        retrieved or written.
+
+    Returns
+    -------
+    butler : `lsst.daf.butler.Butler`
+        A Butler for ``central_repo`` pre-configured to load and store
+        ``instrument_name`` data.
+    """
+    instrument = lsst.obs.base.Instrument.from_string(instrument_class)
+    return Butler(central_repo,
+                  collections=[instrument.makeCollectionName("defaults")],
+                  writeable=True,
+                  inferDefaults=False,
+                  )
 
 
 class MiddlewareInterface:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -141,6 +141,7 @@ class MiddlewareInterface:
                  local_storage: str,
                  prefix: str = "gs://"):
         self._apdb_uri = self._make_apdb_uri()
+        self._apdb_namespace = os.environ.get("NAMESPACE_APDB", None)
         self.central_butler = central_butler
         self.image_host = prefix + image_bucket
         # TODO: _download_store turns MWI into a tagged class; clean this up later
@@ -546,8 +547,8 @@ class MiddlewareInterface:
             pipeline = lsst.pipe.base.Pipeline.fromFile(ap_pipeline_file)
         except FileNotFoundError:
             raise RuntimeError(f"No ApPipe.yaml defined for camera {self.instrument.getName()}")
-        # TODO: Can we write to a configurable apdb schema (see DM-36497)?
         pipeline.addConfigOverride("diaPipe", "apdb.db_url", self._apdb_uri)
+        pipeline.addConfigOverride("diaPipe", "apdb.namespace", self._apdb_namespace)
         return pipeline
 
     def _download(self, remote):

--- a/python/activator/raw.py
+++ b/python/activator/raw.py
@@ -30,6 +30,8 @@ __all__ = ["Snap", "RAW_REGEXP", "get_raw_path"]
 from dataclasses import dataclass
 import re
 
+from .visit import Visit
+
 
 @dataclass(frozen=True)
 class Snap:
@@ -65,6 +67,20 @@ class Snap:
                         )
         else:
             raise ValueError(f"{oid} could not be parsed into a Snap")
+
+    def is_consistent(self, visit: Visit):
+        """Test if this snap could have come from a particular visit.
+
+        Parameters
+        ----------
+        visit : `activator.visit.Visit`
+            The visit from which snaps were expected.
+        """
+        return (self.instrument == visit.instrument
+                and self.detector == visit.detector
+                and self.group == visit.group
+                and self.snap < visit.snaps
+                )
 
 
 # Format for filenames of raws uploaded to image bucket:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -31,13 +31,6 @@ from activator.logger import GCloudStructuredLogFormatter
 class GoogleFormatterTest(unittest.TestCase):
     """Test GCloudStructuredLogFormatter with fake log messages.
     """
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        # Each test has its own handler
-        # logging.basicConfig(handlers=[logging.NullHandler()])
-
     def setUp(self):
         super().setUp()
 

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -144,6 +144,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         # TemporaryDirectory warns on leaks
+        self.interface._repo.cleanup()  # TODO: should MiddlewareInterface have a cleanup method?
         self.workspace.cleanup()
 
     def test_init(self):
@@ -491,6 +492,8 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         # Populate repository.
         self.interface = MiddlewareInterface(central_butler, self.input_data, instrument, workspace.name,
                                              prefix="file://")
+        # TODO: should MiddlewareInterface have a cleanup method?
+        self.addCleanup(tempfile.TemporaryDirectory.cleanup, self.interface._repo)
         self.interface.prep_butler(self.next_visit)
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -99,7 +99,10 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.env_patcher = unittest.mock.patch.dict(os.environ,
-                                                   {"IP_APDB": "localhost"})
+                                                   {"IP_APDB": "localhost",
+                                                    "DB_APDB": "postgres",
+                                                    "USER_APDB": "postgres",
+                                                    })
         cls.env_patcher.start()
 
         super().setUpClass()
@@ -433,7 +436,10 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         super().setUpClass()
 
         cls.env_patcher = unittest.mock.patch.dict(os.environ,
-                                                   {"IP_APDB": "localhost"})
+                                                   {"IP_APDB": "localhost",
+                                                    "DB_APDB": "postgres",
+                                                    "USER_APDB": "postgres",
+                                                    })
         cls.env_patcher.start()
 
     @classmethod

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -120,9 +120,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         instrument_name = "DECam"
         self.input_data = os.path.join(data_dir, "input_data")
         # Have to preserve the tempdir, so that it doesn't get cleaned up.
-        self.repo = tempfile.TemporaryDirectory()
-        self.butler = Butler(Butler.makeRepo(self.repo.name), writeable=True)
-        self.interface = MiddlewareInterface(central_butler, self.input_data, instrument, self.butler,
+        self.workspace = tempfile.TemporaryDirectory()
+        self.interface = MiddlewareInterface(central_butler, self.input_data, instrument,
+                                             self.workspace.name,
                                              prefix="file://")
 
         # coordinates from DECam data in ap_verify_ci_hits2015 for visit 411371
@@ -144,7 +144,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         # TemporaryDirectory warns on leaks
-        self.repo.cleanup()
+        self.workspace.cleanup()
 
     def test_init(self):
         """Basic tests of the initialized interface object.
@@ -467,11 +467,10 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         instrument = "lsst.obs.decam.DarkEnergyCamera"
         data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.input_data = os.path.join(data_dir, "input_data")
-        repo = tempfile.TemporaryDirectory()
+        workspace = tempfile.TemporaryDirectory()
         # TemporaryDirectory warns on leaks; addCleanup also keeps the TD from
         # getting garbage-collected.
-        self.addCleanup(tempfile.TemporaryDirectory.cleanup, repo)
-        self.butler = Butler(Butler.makeRepo(repo.name), writeable=True)
+        self.addCleanup(tempfile.TemporaryDirectory.cleanup, workspace)
 
         # coordinates from DECam data in ap_verify_ci_hits2015 for visit 411371
         ra = 155.4702849608958
@@ -490,7 +489,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.logger_name = "lsst.activator.middleware_interface"
 
         # Populate repository.
-        self.interface = MiddlewareInterface(central_butler, self.input_data, instrument, self.butler,
+        self.interface = MiddlewareInterface(central_butler, self.input_data, instrument, workspace.name,
                                              prefix="file://")
         self.interface.prep_butler(self.next_visit)
         filename = "fakeRawImage.fits"

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -117,7 +117,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                 writeable=False,
                                 inferDefaults=False)
         instrument = "lsst.obs.decam.DarkEnergyCamera"
-        instrument_name = "DECam"
         self.input_data = os.path.join(data_dir, "input_data")
         # Have to preserve the tempdir, so that it doesn't get cleaned up.
         self.workspace = tempfile.TemporaryDirectory()
@@ -130,7 +129,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         dec = -4.950050405424033
         # DECam has no rotator; instrument angle is 90 degrees in our system.
         rot = 90.
-        self.next_visit = Visit(instrument_name,
+        self.next_visit = Visit(instname,
                                 detector=56,
                                 group="1",
                                 snaps=1,

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -148,13 +148,15 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.workspace.cleanup()
 
     def test_get_butler(self):
-        butler = get_central_butler(self.central_repo, "lsst.obs.decam.DarkEnergyCamera")
-        # TODO: better way to test repo location?
-        self.assertTrue(
-            butler.getURI("camera", instrument=instname, run="foo", predict=True).ospath
-            .startswith(self.central_repo))
-        self.assertEqual(list(butler.collections), [f"{instname}/defaults"])
-        self.assertTrue(butler.isWriteable())
+        for butler in [get_central_butler(self.central_repo, "lsst.obs.decam.DarkEnergyCamera"),
+                       get_central_butler(self.central_repo, instname),
+                       ]:
+            # TODO: better way to test repo location?
+            self.assertTrue(
+                butler.getURI("camera", instrument=instname, run="foo", predict=True).ospath
+                .startswith(self.central_repo))
+            self.assertEqual(list(butler.collections), [f"{instname}/defaults"])
+            self.assertTrue(butler.isWriteable())
 
     def test_init(self):
         """Basic tests of the initialized interface object.

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -22,7 +22,7 @@
 import re
 import unittest
 
-from activator.raw import RAW_REGEXP, get_raw_path
+from activator.raw import Snap, RAW_REGEXP, get_raw_path
 
 
 class RawTest(unittest.TestCase):
@@ -55,3 +55,23 @@ class RawTest(unittest.TestCase):
         self.assertEqual(parsed['snap'], str(self.snap))
         self.assertEqual(parsed['expid'], str(self.exposure))
         self.assertEqual(parsed['filter'], str(self.filter))
+
+    def test_snap(self):
+        """Test that Snap objects can be constructed from parseable paths.
+        """
+        path = get_raw_path(self.instrument, self.detector, self.group, self.snap, self.exposure, self.filter)
+        parsed = Snap.from_oid(path)
+        self.assertIsNotNone(parsed)
+        # These tests automatically include type-checking.
+        self.assertEqual(parsed.instrument, self.instrument)
+        self.assertEqual(parsed.detector, self.detector)
+        self.assertEqual(parsed.group, self.group)
+        self.assertEqual(parsed.snap, self.snap)
+        self.assertEqual(parsed.exp_id, self.exposure)
+        self.assertEqual(parsed.filter, self.filter)
+
+    def test_bad_snap(self):
+        path = get_raw_path(self.instrument, f"{self.detector}b", self.group,
+                            self.snap, self.exposure, self.filter)
+        with self.assertRaisesRegex(ValueError, "not .* parsed"):
+            Snap.from_oid(path)


### PR DESCRIPTION
This PR does a large amount of refactoring centered on `activator.py`, plus some minor reimplementation, with the following goals:

- Removing all LSST dependencies, particularly `Butler` and `Instrument`, from `activator.py`.
- Providing a more platform-independent guarantee that local Butler repos will never collide.
- Separating code within `activator.py` that depends on Google components (Storage and PubSub) from that which does not.
- More unit test coverage of functionality that was previously in `activator.py`, which cannot be imported within the standard `rubin-devl` environment.
- Providing more platform-independent configuration of the databases, especially the APDB.