### PR TITLE
DM-36509: Set up test Prompt Processing central repository at USDF

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -67,6 +67,9 @@ On the other hand, using multiple topics is also simple to do.
 Buckets
 =======
 
+Google Cloud
+------------
+
 A single bucket named ``rubin-prompt-proto-main`` has been created to hold the central repository described in `DMTN-219`_, as well as incoming raw images.
 
 The bucket ``rubin-prompt-proto-support-data-template`` contains a pristine copy of the calibration datasets and templates.
@@ -88,6 +91,38 @@ To configure these notifications, in a shell:
 
 This creates a notification on the given topic using JSON format when an object has been finalized (transfer of it has completed).
 Notifications are only sent on this topic for objects with the instrument name as a prefix.
+
+USDF
+----
+
+The bucket ``rubin-pp`` holds incoming raw images.
+
+The bucket ``rubin-pp-users`` holds the central repository described in `DMTN-219`_.
+The central repository currently contains:
+
+* HSC: a copy of `ap_verify_ci_cosmos_pdr2/preloaded@u/kfindeisen/DM-35052-expansion <https://github.com/lsst/ap_verify_ci_cosmos_pdr2/tree/u/kfindeisen/DM-35052-expansion/preloaded>`_.
+
+``rubin-pp`` has had notifications configured for it; these publish to a Kafka topic.
+
+The default Rubin users' setup changes how S3 credentials are handled on ``rubin-devl``.
+The best way to set up credentials for either Butler or S3 commands is to run:
+
+.. code-block:: sh
+
+   singularity exec /sdf/sw/s3/aws-cli_latest.sif aws configure
+
+and follow the prompts.
+
+The buckets can be inspected by calling the following from ``rubin-devl``:
+
+.. code-block:: sh
+
+   alias s3="singularity exec /sdf/sw/s3/aws-cli_latest.sif aws --endpoint-url https://s3dfrgw.slac.stanford.edu s3"
+   s3 [ls|cp|rm] s3://rubin-pp-users/<path>
+
+.. note::
+
+   You must pass the ``--endpoint-url`` argument even if you have ``S3_ENDPOINT_URL`` defined.
 
 Prototype Service
 =================

--- a/etc/db_butler.yaml
+++ b/etc/db_butler.yaml
@@ -1,3 +1,5 @@
+# Seed config for generating Prompt Prototype central repo.
+# This is the test repo to be used with upload.py, not the repo for processing AuxTel data.
 registry:
-  db: postgresql://postgres@localhost:5432/
-  namespace: support_data_template
+  db: postgresql://pp@usdf-prompt-processing-dev.slac.stanford.edu/ppcentralbutler
+  namespace: pp_central_repo


### PR DESCRIPTION
This PR updates the example Butler config and the Playbook to reflect USDF infrastructure. I've not deleted the Google Cloud equivalents yet, since that is the only platform on which the prototype is operational.