### PR TITLE
DM-36712: Migrate activator.py to use Kafka/Knative

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -4,6 +4,7 @@ RUN source /opt/lsst/software/stack/loadLSST.bash \
     && mamba install -y \
         flask \
         gunicorn \
+        python-confluent-kafka \
         google-cloud-pubsub \
         google-cloud-sdk \
         google-cloud-storage \

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -6,4 +6,6 @@ RUN source /opt/lsst/software/stack/loadLSST.bash \
         gunicorn \
         google-cloud-pubsub \
         google-cloud-sdk \
-        google-cloud-storage
+        google-cloud-storage \
+    && pip install --no-input \
+        cloudevents

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -5,8 +5,5 @@ RUN source /opt/lsst/software/stack/loadLSST.bash \
         flask \
         gunicorn \
         python-confluent-kafka \
-        google-cloud-pubsub \
-        google-cloud-sdk \
-        google-cloud-storage \
     && pip install --no-input \
         cloudevents

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -40,7 +40,6 @@ from .visit import Visit
 
 PROJECT_ID = "prompt-proto"
 
-verification_token = os.environ["PUBSUB_VERIFICATION_TOKEN"]
 # The short name for the instrument.
 instrument_name = os.environ["RUBIN_INSTRUMENT"]
 # URI to the main repository containing calibs and templates
@@ -156,8 +155,6 @@ def next_visit_handler() -> Tuple[str, int]:
     status : `int`
         The HTTP response status code to return to the client.
     """
-    if request.args.get("token", "") != verification_token:
-        return "Invalid request", 400
     subscription = subscriber.create_subscription(
         topic=topic_path,
         ack_deadline_seconds=60,

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -31,7 +31,7 @@ from typing import Optional, Tuple
 from flask import Flask, request
 from google.cloud import pubsub_v1, storage
 
-from .logger import setup_google_logger
+from .logger import setup_usdf_logger
 from .make_pgpass import make_pgpass
 from .middleware_interface import get_central_butler, MiddlewareInterface
 from .raw import Snap
@@ -51,7 +51,7 @@ timeout = os.environ.get("IMAGE_TIMEOUT", 50)
 # Absolute path on this worker's system where local repos may be created
 local_repos = os.environ.get("LOCAL_REPOS", "/tmp")
 
-setup_google_logger(
+setup_usdf_logger(
     labels={"instrument": instrument_name},
 )
 _log = logging.getLogger("lsst." + __name__)

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["GCloudStructuredLogFormatter", "setup_google_logger"]
+__all__ = ["GCloudStructuredLogFormatter", "setup_google_logger", "setup_usdf_logger"]
 
 import json
 import logging
@@ -46,6 +46,27 @@ def setup_google_logger(labels=None):
     """
     log_handler = logging.StreamHandler()
     log_handler.setFormatter(GCloudStructuredLogFormatter(labels))
+    logging.basicConfig(handlers=[log_handler])
+    logging.captureWarnings(True)
+    return log_handler
+
+
+def setup_usdf_logger(labels=None):
+    """Set global logging settings for prompt_prototype.
+
+    Calling this function redirects all warnings to go through the logger.
+
+    Parameters
+    ----------
+    labels : `dict` [`str`, `str`]
+        Any metadata that should be attached to all logs.
+
+    Returns
+    -------
+    handler : `logging.Handler`
+        The handler used by the root logger.
+    """
+    log_handler = logging.StreamHandler()
     logging.basicConfig(handlers=[log_handler])
     logging.captureWarnings(True)
     return log_handler


### PR DESCRIPTION
This PR replaces all Google-specific components (including the logger, which doesn't depend on Google APIs as such) with USDF-appropriate components, and documents how to run the activator on our Kubernetes cluster.