### PR TITLE
DM-36791: Use unique IDs in upload.py output

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -284,7 +284,7 @@ Eventually a set of parallel processes running on multiple nodes will be needed 
 
 .. note::
 
-   ``upload.py`` uploads from the same small pool of raws every time it is run, while the AP pipeline assumes that every visit has unique visit IDs.
+   ``upload.py`` uploads from the same small pool of raws every time it is run, while the APDB assumes that every visit has unique timestamps.
    This causes collisions in the APDB that crash the pipeline.
    To prevent this, follow the reset instructions under `Databases`_ before calling ``upload.py`` again.
 

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -269,7 +269,7 @@ Install the prototype code:
 
     git clone https://github.com/lsst-dm/prompt_prototype
 
-Command line arguments are the instrument name (currently HSC only; other values will upload dummy raws that the pipeline can't process) and the number of groups of images to send.
+Command line arguments are the instrument name (currently HSC only) and the number of groups of images to send.
 
 Sample command line:
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -102,7 +102,7 @@ def send_next_visit(producer, group, visit_infos):
         producer.produce(topic, data)
 
 
-def make_exposure_id(instrument, group, snap):
+def make_exposure_id(instrument, group_num, snap):
     """Generate an exposure ID from an exposure's other metadata.
 
     The exposure ID is purely a placeholder, and does not conform to any
@@ -112,8 +112,8 @@ def make_exposure_id(instrument, group, snap):
     ----------
     instrument : `str`
         The short name of the instrument.
-    group : `int`
-        A group ID.
+    group_num : `int`
+        The integer used to generate a group ID.
     snap : `int`
         A snap ID.
 
@@ -121,10 +121,10 @@ def make_exposure_id(instrument, group, snap):
     -------
     exposure : `int`
         An exposure ID that is likely to be unique for each combination of
-        ``group`` and ``snap``, for a given ``instrument``.
+        ``group_num`` and ``snap``, for a given ``instrument``.
     """
-    exposure_id = (group // 100_000) * 100_000
-    exposure_id += (group % 100_000) * INSTRUMENTS[instrument].n_snaps
+    exposure_id = (group_num // 100_000) * 100_000
+    exposure_id += (group_num % 100_000) * INSTRUMENTS[instrument].n_snaps
     exposure_id += snap
     return exposure_id
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -102,11 +102,30 @@ def send_next_visit(producer, group, visit_infos):
         producer.produce(topic, data)
 
 
+def make_hsc_id(group_num, snap):
+    """Generate an exposure ID that the Butler can parse as a valid HSC ID.
+
+    Parameters
+    ----------
+    group_num : `int`
+        The integer used to generate a group ID.
+    snap : `int`
+        A snap ID.
+
+    Returns
+    -------
+    exposure : `int`
+        An exposure ID that is likely to be unique for each combination of
+        ``group`` and ``snap``.
+    """
+    exposure_id = (group_num // 100_000) * 100_000
+    exposure_id += (group_num % 100_000) * INSTRUMENTS['HSC'].n_snaps
+    exposure_id += snap
+    return exposure_id
+
+
 def make_exposure_id(instrument, group_num, snap):
     """Generate an exposure ID from an exposure's other metadata.
-
-    The exposure ID is purely a placeholder, and does not conform to any
-    instrument's rules for how exposure IDs should be generated.
 
     Parameters
     ----------
@@ -123,10 +142,11 @@ def make_exposure_id(instrument, group_num, snap):
         An exposure ID that is likely to be unique for each combination of
         ``group_num`` and ``snap``, for a given ``instrument``.
     """
-    exposure_id = (group_num // 100_000) * 100_000
-    exposure_id += (group_num % 100_000) * INSTRUMENTS[instrument].n_snaps
-    exposure_id += snap
-    return exposure_id
+    match instrument:
+        case "HSC":
+            return make_hsc_id(group_num, snap)
+        case _:
+            raise NotImplementedError(f"Exposure ID generation not supported for {instrument}.")
 
 
 def main():

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -114,18 +114,23 @@ def make_hsc_id(group_num, snap):
 
     Returns
     -------
-    exposure : `int`
+    exposure_header : `str`
         An exposure ID that is likely to be unique for each combination of
-        ``group`` and ``snap``.
+        ``group`` and ``snap``, in the form it appears in HSC headers.
+    exposure_num : `int`
+        The exposure ID genereated by Middleware from ``exposure_header``.
     """
     exposure_id = (group_num // 100_000) * 100_000
     exposure_id += (group_num % 100_000) * INSTRUMENTS['HSC'].n_snaps
     exposure_id += snap
-    return exposure_id
+    return str(exposure_id), exposure_id
 
 
 def make_exposure_id(instrument, group_num, snap):
     """Generate an exposure ID from an exposure's other metadata.
+
+    The exposure ID is designed for insertion into an image header, and is
+    therefore a string in the instrument's native format.
 
     Parameters
     ----------
@@ -138,13 +143,19 @@ def make_exposure_id(instrument, group_num, snap):
 
     Returns
     -------
-    exposure : `int`
+    exposure_key : `str`
+        The header key under which ``instrument`` stores the exposure ID.
+    exposure_header : `str`
         An exposure ID that is likely to be unique for each combination of
-        ``group_num`` and ``snap``, for a given ``instrument``.
+        ``group_num`` and ``snap``, for a given ``instrument``, in the format
+        for ``instrument``'s header.
+    exposure_num : `int`
+        An exposure ID equivalent to ``exposure_header`` in the format expected
+        by Gen 3 Middleware.
     """
     match instrument:
         case "HSC":
-            return make_hsc_id(group_num, snap)
+            return "EXP-ID", *make_hsc_id(group_num, snap)
         case _:
             raise NotImplementedError(f"Exposure ID generation not supported for {instrument}.")
 


### PR DESCRIPTION
This PR simplifies `upload.py` by removing dummy ("random") file support, and adds an exposure ID injection step to the raw upload process. This change allows the Butler to see each visit/snap as a distinct exposure ID, although it still doesn't allow uploads to be rerun without clearing the APDB first.