### PR TITLE
DM-37068: Clear out conflicting datasets before prompt processing runs

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -145,7 +145,7 @@ def parse_next_visit(http_request):
     if not event.data:
         raise ValueError("empty CloudEvent received")
 
-    # TODO: may need to sync this with upload.py implementation
+    # Message format is determined by the nextvisit-start deployment.
     data = json.loads(event.data)
     return Visit(**data)
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -518,6 +518,8 @@ class MiddlewareInterface:
         output_run = f"{self.output_collection}/{self.instrument.makeCollectionTimestamp()}"
         self.butler.registry.registerCollection(output_run, CollectionType.RUN)
         _prepend_collection(self.butler, self.output_collection, [output_run])
+        # TODO: remove after DM-36162
+        self._clean_unsafe_datasets(self.butler, output_run)
         return output_run
 
     def _prep_pipeline(self, visit: Visit) -> None:

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -270,9 +270,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected_shards.update({157218, 157229})
         self._check_imports(self.interface.butler, detector=5, expected_shards=expected_shards)
 
-    # TODO: regression test for prep_butler having a stale cache for the butler it's updating.
-    # This may be impossible to unit test, since it seems to depend on Google-side parallelism.
-
     def test_ingest_image(self):
         self.interface.prep_butler(self.next_visit)  # Ensure raw collections exist.
         filename = "fakeRawImage.fits"


### PR DESCRIPTION
This PR adds code for removing shared (usually init-output) datasets from an output run, making it possible to reuse runs for multiple groups and detectors. Actually implementing reuse is deferred to [DM-36586](https://jira.lsstcorp.org/browse/DM-36586).

The deletion is a stopgap until [DM-36162](https://jira.lsstcorp.org/browse/DM-36162) gives us better tools for handling preexisting or conflicting datasets, so the new code is all written on the assumption that it will be removed later.