### PR TITLE
DM-37258: Logs getting dropped in prompt processing

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -233,6 +233,8 @@ The following environment variables are optional:
 * USER_APDB: database user for the APDB, default "postgres"
 * USER_REGISTRY: database user for the registry database, default "postgres"
 * NAMESPACE_APDB: the database namespace for the APDB, defaults to the DB's default namespace
+* SERVICE_LOG_LEVELS: requested logging levels in the format of `Middleware's --log-level argument <https://pipelines.lsst.io/v/daily/modules/lsst.daf.butler/scripts/butler.html#cmdoption-butler-log-level>`_.
+  Default is to log prompt_prototype at DEBUG, other LSST code at INFO, and third-party code at WARNING.
 
 Secrets are configured through the makefile and ``kustomization.yaml``.
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -216,6 +216,7 @@ def next_visit_handler() -> Tuple[str, int]:
     status : `int`
         The HTTP response status code to return to the client.
     """
+    _log.info(f"Starting next_visit_handler for {request}.")
     consumer.subscribe([bucket_topic])
     _log.debug(f"Created subscription to '{bucket_topic}'")
     try:
@@ -298,6 +299,8 @@ def next_visit_handler() -> Tuple[str, int]:
             return "Timed out waiting for images", 500
     finally:
         consumer.unsubscribe()
+        # Want to know when the handler exited for any reason.
+        _log.info("next_visit handling completed.")
 
 
 @app.errorhandler(500)

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -30,6 +30,26 @@ except ModuleNotFoundError:
     lsst_log = None
 
 
+def _parse_log_levels(spec):
+    """Parse a string description of logging levels.
+
+    Parameters
+    ----------
+    spec : `str`
+        A string consisting of space-separated pairs of logger=level
+        specifications. No attempt is made to validate whether the string
+        conforms to this format. "." refers to the root logger.
+
+    Returns
+    -------
+    levels : `list` [`tuple` [`str`, `str`]]
+        A list of tuples whose first element is a logger (root logger
+        represented by `None`) and whose second element is a logging level.
+    """
+    levels = [tuple(s.split("=", maxsplit=1)) for s in spec.split(None)]
+    return [(k if k != "." else None, v) for k, v in levels]
+
+
 def _set_lsst_logging_levels():
     """Set up standard logging levels for LSST code.
 

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -46,6 +46,18 @@ def _set_lsst_logging_levels():
     logging.getLogger("lsst").setLevel(logging.INFO)
 
 
+def _channel_all_to_pylog():
+    """Set up redirection of lsst.log and warning output to the Python logger.
+
+    This ensures that all service output is formatted consistently, making it easier to parse.
+    """
+    if lsst_log is not None:
+        lsst_log.configure_pylog_MDC("DEBUG", MDC_class=None)
+        lsst_log.usePythonLogging()
+
+    logging.captureWarnings(True)
+
+
 # TODO: replace with something more extensible, once we know what needs to
 # vary besides the formatter (handler type?).
 def setup_google_logger(labels=None):
@@ -68,7 +80,7 @@ def setup_google_logger(labels=None):
     log_handler = logging.StreamHandler()
     log_handler.setFormatter(GCloudStructuredLogFormatter(labels))
     logging.basicConfig(handlers=[log_handler])
-    logging.captureWarnings(True)
+    _channel_all_to_pylog()
     _set_lsst_logging_levels()
     return log_handler
 
@@ -90,7 +102,7 @@ def setup_usdf_logger(labels=None):
     """
     log_handler = logging.StreamHandler()
     logging.basicConfig(handlers=[log_handler])
-    logging.captureWarnings(True)
+    _channel_all_to_pylog()
     _set_lsst_logging_levels()
     return log_handler
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -44,7 +44,7 @@ logging.basicConfig(
     style="{",
 )
 _log = logging.getLogger("lsst." + __name__)
-_log.setLevel(logging.DEBUG)
+_log.setLevel(logging.INFO)
 
 
 def process_group(producer, visit_infos, uploader):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -25,7 +25,33 @@ import json
 import logging
 import unittest
 
-from activator.logger import GCloudStructuredLogFormatter
+from activator.logger import GCloudStructuredLogFormatter, _parse_log_levels
+
+
+class ParseLogLevelsTest(unittest.TestCase):
+    """Test _parse_log_levels.
+
+    Currently _parse_log_levels does not do input validation, so behavior for
+    invalid specs is undefined.
+    """
+    def test_single_level(self):
+        self.assertEqual(_parse_log_levels("lsst.daf.butler=DEBUG"), [("lsst.daf.butler", "DEBUG")])
+
+    def test_multi_level(self):
+        self.assertEqual(_parse_log_levels("lsst.daf.butler=DEBUG lsst.ip.isr=WARNING"),
+                         [("lsst.daf.butler", "DEBUG"), ("lsst.ip.isr", "WARNING")]
+                         )
+
+    def test_empty(self):
+        self.assertEqual(_parse_log_levels(""), [])
+
+    def test_single_root(self):
+        self.assertEqual(_parse_log_levels(".=WARNING"), [(None, "WARNING")])
+
+    def test_root_(self):
+        self.assertEqual(_parse_log_levels("lsst.daf.butler=DEBUG .=WARNING lsst=INFO"),
+                         [("lsst.daf.butler", "DEBUG"), (None, "WARNING"), ("lsst", "INFO")]
+                         )
 
 
 class GoogleFormatterTest(unittest.TestCase):


### PR DESCRIPTION
This PR fixes and refactors the logging configuration to better emulate the behavior expected from `pipetask` and BPS. It also adds a log level environment variable, which was requested for debugging our slow run times.