### PR TITLE
DM-36586: Use a single output run in Prompt Prototype

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -320,11 +320,12 @@ Run:
 and look up the ``EXTERNAL-IP``; set ``KAFKA_CLUSTER=<ip>:9094``.
 The IP address is fixed, so you should only need to look it up once.
 
-Install the prototype code:
+Install the prototype code, and set it up before use:
 
 .. code-block:: sh
 
     git clone https://github.com/lsst-dm/prompt_prototype
+    setup -r prompt_prototype
 
 The tester scripts send ``next_visit`` events for each detector via Kafka on the ``next-visit-topic`` topic.
 They then upload a batch of files representing the snaps of the visit to the ``rubin-pp`` S3 bucket, simulating incoming raw images.

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -200,7 +200,7 @@ USDF
 
 The service can be controlled with ``kubectl`` from ``rubin-devl``.
 You must first `get credentials for the development cluster <https://k8s.slac.stanford.edu/usdf-prompt-processing-dev>`_ on the web; ignore the installation instructions and copy the commands from the second box.
-Credentials are good for roughly one work day.
+Credentials must be renewed if you get a "cannot fetch token: 400 Bad Request" error when running ``kubectl``.
 
 Each time the service container is updated, a new revision of the service should be edited and deployed.
 (Continuous deployment has not yet been set up.)

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -99,8 +99,8 @@ The bucket ``rubin-pp`` holds incoming raw images.
 
 The bucket ``rubin-pp-users`` holds:
 
-* The central repository described in `DMTN-219`_.
-  This repository currently contains a copy of HSC data `ap_verify_ci_cosmos_pdr2/preloaded@u/kfindeisen/DM-35052-expansion <https://github.com/lsst/ap_verify_ci_cosmos_pdr2/tree/u/kfindeisen/DM-35052-expansion/preloaded>`_.
+* ``rubin-pp-users/central_repo/`` contains the central repository described in `DMTN-219`_.
+  This repository currently contains a copy of HSC RC2 data, uploaded with ``make_hsc_rc2_export.py`` and ``make_template_export``.
 
 * ``rubin-pp-users/unobserved/`` contains raw files that the upload script(s) can draw from to create incoming raws.
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -296,6 +296,8 @@ def next_visit_handler() -> Tuple[str, int]:
             # TODO: broadcast alerts here
             # TODO: call export_outputs on success or permanent failure in DM-34141
             mwi.export_outputs(expected_visit, expid_set)
+            # Clean only if export successful.
+            mwi.clean_local_repo(expected_visit, expid_set)
             return "Pipeline executed", 200
         else:
             _log.error(f"Timed out waiting for images for {expected_visit}.")

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -905,8 +905,8 @@ def _prepend_collection(butler: Butler, chain: str, new_collections: collections
         The butler in which the collections exist.
     chain : `str`
         The chained collection to prepend to.
-    new_collections : iterable [`str`]
-        The collections to prepend to ``chain``.
+    new_collections : sequence [`str`]
+        The collections to prepend to ``chain``, in order.
 
     Notes
     -----
@@ -914,3 +914,27 @@ def _prepend_collection(butler: Butler, chain: str, new_collections: collections
     """
     old_chain = butler.registry.getCollectionChain(chain)  # May be empty
     butler.registry.setCollectionChain(chain, list(new_collections) + list(old_chain), flatten=False)
+
+
+def _remove_from_chain(butler: Butler, chain: str, old_collections: collections.abc.Iterable[str]) -> None:
+    """Remove a specific collection from a chain.
+
+    This function has no effect if the collection is not in the chain.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        The butler in which the collections exist.
+    chain : `str`
+        The chained collection to remove from.
+    old_collections : iterable [`str`]
+        The collections to remove from ``chain``.
+
+    Notes
+    -----
+    This function is not safe against concurrent modifications to ``chain``.
+    """
+    contents = list(butler.registry.getCollectionChain(chain))
+    for old in set(old_collections).intersection(contents):
+        contents.remove(old)
+    butler.registry.setCollectionChain(chain, contents, flatten=False)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -641,8 +641,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "raw", raw_collection, self.raw_data_id),
             1)
-        # Did not export raws directly to raw/all.
-        self.assertEqual(central_butler.registry.getCollectionType(raw_collection), CollectionType.CHAINED)
         self.assertEqual(self._count_datasets(central_butler, "calexp", export_collection), 1)
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "calexp", export_collection, self.processed_data_id),
@@ -682,8 +680,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "raw", raw_collection, self.second_data_id),
             1)
-        # Did not export raws directly to raw/all.
-        self.assertEqual(central_butler.registry.getCollectionType(raw_collection), CollectionType.CHAINED)
         self.assertEqual(self._count_datasets(central_butler, "calexp", export_collection), 2)
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "calexp", export_collection, self.processed_data_id),

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import dataclasses
+import datetime
 import itertools
 import tempfile
 import time
@@ -109,6 +110,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                                    {"IP_APDB": "localhost",
                                                     "DB_APDB": "postgres",
                                                     "USER_APDB": "postgres",
+                                                    "K_REVISION": "prompt-proto-service-042",
                                                     })
         cls.env_patcher.start()
 
@@ -372,6 +374,19 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "No data to process"):
             self.interface.run_pipeline(self.next_visit, {2})
 
+    def test_get_output_run(self):
+        for date in [datetime.date.today(), datetime.datetime.today()]:
+            out_run = self.interface._get_output_run(self.next_visit, date)
+            self.assertEqual(out_run,
+                             f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
+                             "/ApPipe/prompt-proto-service-042"
+                             )
+            init_run = self.interface._get_init_output_run(self.next_visit, date)
+            self.assertEqual(init_run,
+                             f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
+                             "/ApPipe/prompt-proto-service-042"
+                             )
+
     def _assert_in_collection(self, butler, collection, dataset_type, data_id):
         # Pass iff any dataset matches the query, no need to check them all.
         for dataset in butler.registry.queryDatasets(dataset_type, collections=collection, dataId=data_id):
@@ -503,6 +518,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                                    {"IP_APDB": "localhost",
                                                     "DB_APDB": "postgres",
                                                     "USER_APDB": "postgres",
+                                                    "K_REVISION": "prompt-proto-service-042",
                                                     })
         cls.env_patcher.start()
 

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -75,11 +75,11 @@ def fake_file_data(filename, dimensions, instrument, visit):
                                           "instrument": instrument.getName()},
                                          universe=dimensions)
 
-    time = astropy.time.Time("2015-02-18T05:28:18.716517500", scale="tai")
+    start_time = astropy.time.Time("2015-02-18T05:28:18.716517500", scale="tai")
     obs_info = astro_metadata_translator.makeObservationInfo(
         instrument=instrument.getName(),
-        datetime_begin=time,
-        datetime_end=time + 30*u.second,
+        datetime_begin=start_time,
+        datetime_end=start_time + 30*u.second,
         exposure_id=exposure_id,
         visit_id=exposure_id,
         boresight_rotation_angle=astropy.coordinates.Angle(visit.cameraAngle*u.degree),

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -646,7 +646,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
 
         central_butler = Butler(self.central_repo.name, writeable=False)
         raw_collection = f"{instname}/raw/all"
-        export_collection = f"{instname}/prompt-results"
+        date = datetime.datetime.now(datetime.timezone.utc)
+        export_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
+                            "/ApPipe/prompt-proto-service-042"
         self.assertEqual(self._count_datasets(central_butler, "raw", raw_collection), 1)
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "raw", raw_collection, self.raw_data_id),
@@ -679,7 +681,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
 
         central_butler = Butler(self.central_repo.name, writeable=False)
         raw_collection = f"{instname}/raw/all"
-        export_collection = f"{instname}/prompt-results"
+        date = datetime.datetime.now(datetime.timezone.utc)
+        export_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
+                            "/ApPipe/prompt-proto-service-042"
         self.assertEqual(self._count_datasets(central_butler, "raw", raw_collection), 2)
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "raw", raw_collection, self.raw_data_id),


### PR DESCRIPTION
This PR replaces the per-visit raw collection and per-processing output collection with a single raw collection and a per-pipeline output collection, avoiding some scaling and concurrency issues in the central repository. However, the latter change required some reworking of `MiddlewareInterface`, which had assumed that each output collection was new and unique.