### PR TITLE
DM-37072: Expand HSC calibs and templates in central repo

### DIFF
--- a/bin.src/make_remote_butler.py
+++ b/bin.src/make_remote_butler.py
@@ -117,6 +117,11 @@ def _hsc_rc2(butler):
             "HSC/calib/DM-28636",
         ],
     )
+
+    butler.registry.registerCollection(
+        instrument.makeUnboundedCalibrationRunName(),
+        type=CollectionType.CHAINED
+    )
     butler.registry.setCollectionChain(
         instrument.makeUnboundedCalibrationRunName(),
         [

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -194,7 +194,7 @@ def upload_hsc_images(dest_bucket, group_id, butler, refs):
                 ref.dataId["detector"],
                 group_id,
                 0,
-                ref.dataId["exposure"],
+                exposure_num,
                 ref.dataId["physical_filter"],
             )
             transferred = butler.retrieveArtifacts(


### PR DESCRIPTION
This is a continuation of https://github.com/lsst-dm/prompt_prototype/pull/44 , to fix two bugs there. 

