### PR TITLE
DM-36162: Upgrade from SimplePipelineExecutor in prompt prototype

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -87,12 +87,6 @@ storage_client = boto3.client('s3', endpoint_url=s3_endpoint)
 central_butler = get_central_butler(calib_repo, instrument_name)
 # local_repo is a temporary directory with the same lifetime as this process.
 local_repo = make_local_repo(local_repos, central_butler, instrument_name)
-# Initialize middleware interface.
-mwi = MiddlewareInterface(central_butler,
-                          image_bucket,
-                          instrument_name,
-                          skymap,
-                          local_repo.name)
 
 
 def check_for_snap(
@@ -235,6 +229,13 @@ def next_visit_handler() -> Tuple[str, int]:
             f"Expected {instrument_name}, received {expected_visit.instrument}."
         expid_set = set()
 
+        # Create a fresh MiddlewareInterface object to avoid accidental
+        # "cross-talk" between different visits.
+        mwi = MiddlewareInterface(central_butler,
+                                  image_bucket,
+                                  instrument_name,
+                                  skymap,
+                                  local_repo.name)
         # Copy calibrations for this detector/visit
         mwi.prep_butler(expected_visit)
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -35,7 +35,7 @@ from flask import Flask, request
 
 from .logger import setup_usdf_logger
 from .make_pgpass import make_pgpass
-from .middleware_interface import get_central_butler, MiddlewareInterface
+from .middleware_interface import get_central_butler, make_local_repo, MiddlewareInterface
 from .raw import Snap
 from .visit import Visit
 
@@ -84,12 +84,15 @@ consumer = kafka.Consumer({
 
 storage_client = boto3.client('s3', endpoint_url=s3_endpoint)
 
+central_butler = get_central_butler(calib_repo, instrument_name)
+# local_repo is a temporary directory with the same lifetime as this process.
+local_repo = make_local_repo(local_repos, central_butler, instrument_name)
 # Initialize middleware interface.
-mwi = MiddlewareInterface(get_central_butler(calib_repo, instrument_name),
+mwi = MiddlewareInterface(central_butler,
                           image_bucket,
                           instrument_name,
                           skymap,
-                          local_repos)
+                          local_repo.name)
 
 
 def check_for_snap(

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -133,10 +133,9 @@ class MiddlewareInterface:
     ingest the data when it is available, and run the difference imaging
     pipeline, all in that local butler.
 
-    Each instance may be used for processing more than one group-detector
-    combination, designated by the `Visit` parameter to certain methods. There
-    is no guarantee that a processing run may, or may not, share a group,
-    detector, or both with a previous run handled by the same object.
+    Each instance must be used for processing only one group-detector
+    combination. The object may contain state that is unique to a particular
+    processing run.
 
     ``MiddlewareInterface`` objects are not thread- or process-safe. It is up
     to the client to avoid conflicts from multiple objects trying to access the

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -358,10 +358,17 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             mock.return_value = file_data
             self.interface.ingest_image(self.next_visit, filename)
 
-        with unittest.mock.patch("activator.middleware_interface.SimplePipelineExecutor.run") as mock_run:
+        with unittest.mock.patch(
+                "activator.middleware_interface.SeparablePipelineExecutor.pre_execute_qgraph") \
+                as mock_preexec, \
+             unittest.mock.patch("activator.middleware_interface.SeparablePipelineExecutor.run_pipeline") \
+                as mock_run:
             with self.assertLogs(self.logger_name, level="INFO") as logs:
                 self.interface.run_pipeline(self.next_visit, {1})
-        mock_run.assert_called_once_with(register_dataset_types=True)
+        mock_preexec.assert_called_once()
+        # Pre-execution may have other arguments as needed; no requirement either way.
+        self.assertEqual(mock_preexec.call_args.kwargs["register_dataset_types"], True)
+        mock_run.assert_called_once()
         # Check that we configured the right pipeline.
         self.assertIn("End to end Alert Production pipeline specialized for HiTS-2015",
                       "\n".join(logs.output))


### PR DESCRIPTION
This PR redesigns `MiddlewareInterface` to be a per-exposure rather than a per-worker object. This change will make it much easier and more foolproof to work with `MiddlewareInterface` in the future, because it no longer needs to avoid storing per-exposure state. This done, the PR replaces `MiddlewareInterface`'s use of `SimplePipelineExecutor` with the `SeparablePipelineExecutor` introduced in lsst/ctrl_mpexec#230.

~The changes to `build-service.yml` and `Dockerfile.activator` are *not* part of the PR, and were temporary hacks to get a service container that had access to `SeparablePipelineExecutor`.~ I intend to wait until lsst/ctrl_mpexec#230 is incorporated into a nightly/weekly before merging this PR; this will allow all actions to complete without hacks.