### PR TITLE
DM-38752: Output products can go to the wrong collection

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -576,7 +576,7 @@ class MiddlewareInterface:
 
     def _get_init_output_run(self,
                              visit: FannedOutVisit,
-                             date: datetime.date = datetime.datetime.now(datetime.timezone.utc)) -> str:
+                             date: datetime.date | None = None) -> str:
         """Generate a deterministic init-output collection name that avoids
         configuration conflicts.
 
@@ -584,21 +584,24 @@ class MiddlewareInterface:
         ----------
         visit : FannedOutVisit
             Group of snaps whose processing goes into the run.
-        date : `datetime.date`
-            Date of the processing run (not observation!)
+        date : `datetime.date`, optional
+            Date of the processing run (not observation!), defaults to the UTC
+            date this method was called.
 
         Returns
         -------
         run : `str`
             The run in which to place pipeline init-outputs.
         """
+        if date is None:
+            date = datetime.datetime.now(datetime.timezone.utc)
         # Current executor requires that init-outputs be in the same run as
         # outputs. This can be changed once DM-36162 is done.
         return self._get_output_run(visit, date)
 
     def _get_output_run(self,
                         visit: FannedOutVisit,
-                        date: datetime.date = datetime.datetime.now(datetime.timezone.utc)) -> str:
+                        date: datetime.date | None = None) -> str:
         """Generate a deterministic collection name that avoids version or
         provenance conflicts.
 
@@ -606,14 +609,17 @@ class MiddlewareInterface:
         ----------
         visit : FannedOutVisit
             Group of snaps whose processing goes into the run.
-        date : `datetime.date`
-            Date of the processing run (not observation!)
+        date : `datetime.date`, optional
+            Date of the processing run (not observation!), defaults to the UTC
+            date this method was called.
 
         Returns
         -------
         run : `str`
             The run in which to place processing outputs.
         """
+        if date is None:
+            date = datetime.datetime.now(datetime.timezone.utc)
         pipeline_name, _ = os.path.splitext(os.path.basename(self._get_pipeline_file(visit)))
         # Order optimized for S3 bucket -- filter out as many files as soon as possible.
         return self.instrument.makeCollectionName(

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -224,7 +224,7 @@ def upload_from_raws(kafka_url, instrument, raw_pool, src_bucket, dest_bucket, n
 
     for i, true_group in enumerate(itertools.islice(raw_pool, n_groups)):
         group = str(group_base + i)
-        _log.debug(f"Processing group {group} from unobserved {true_group}...")
+        _log.info(f"Processing group {group} from unobserved {true_group}...")
         # snap_dict maps snap_id to {visit: blob}
         snap_dict = {}
         # Copy all the visit-blob dictionaries under each snap_id,
@@ -253,7 +253,6 @@ def upload_from_raws(kafka_url, instrument, raw_pool, src_bucket, dest_bucket, n
                 dest_bucket.upload_fileobj(buffer, filename)
 
         process_group(kafka_url, visit_infos, upload_from_pool)
-        _log.info("Slewing to next group")
         time.sleep(SLEW_INTERVAL)
 
 

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -46,7 +46,7 @@ logging.basicConfig(
     style="{",
 )
 _log = logging.getLogger("lsst." + __name__)
-_log.setLevel(logging.DEBUG)
+_log.setLevel(logging.INFO)
 
 
 def main():

--- a/python/tester/utils.py
+++ b/python/tester/utils.py
@@ -30,7 +30,7 @@ from astropy.io import fits
 
 
 _log = logging.getLogger("lsst." + __name__)
-_log.setLevel(logging.DEBUG)
+_log.setLevel(logging.INFO)
 
 max_exposure = {
     "HSC": 21474800,

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -686,8 +686,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         """Create a mock pipeline execution that stores a calexp for self.raw_data_id.
         """
         exp = lsst.afw.image.ExposureF(20, 20)
-        run1 = self.interface._prep_collections()
-        run2 = self.second_interface._prep_collections()
         self.processed_data_id = {(k if k != "exposure" else "visit"): v for k, v in self.raw_data_id.items()}
         self.second_processed_data_id = {(k if k != "exposure" else "visit"): v
                                          for k, v in self.second_data_id.items()}
@@ -696,8 +694,8 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         butler_tests.addDatasetType(self.interface.butler, "calexp", {"instrument", "visit", "detector"},
                                     "ExposureF")
         self.second_interface.butler.registry.refresh()
-        self.interface.butler.put(exp, "calexp", self.processed_data_id, run=run1)
-        self.second_interface.butler.put(exp, "calexp", self.second_processed_data_id, run=run2)
+        self.interface.butler.put(exp, "calexp", self.processed_data_id)
+        self.second_interface.butler.put(exp, "calexp", self.second_processed_data_id)
 
     def _count_datasets(self, butler, types, collections):
         return len(set(butler.registry.queryDatasets(types, collections=collections)))

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -130,12 +130,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                      collections=[f"{instname}/defaults"],
                                      writeable=False,
                                      inferDefaults=False)
-        instrument = "lsst.obs.decam.DarkEnergyCamera"
         self.input_data = os.path.join(data_dir, "input_data")
         self.local_repo = make_local_repo(tempfile.gettempdir(), self.central_butler, instname)
-        self.interface = MiddlewareInterface(self.central_butler, self.input_data, instrument,
-                                             skymap_name, self.local_repo.name,
-                                             prefix="file://")
 
         # coordinates from DECam data in ap_verify_ci_hits2015 for visit 411371
         ra = 155.4702849608958
@@ -159,6 +155,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                          totalCheckpoints=1,
                                          )
         self.logger_name = "lsst.activator.middleware_interface"
+        self.interface = MiddlewareInterface(self.central_butler, self.input_data, self.next_visit,
+                                             skymap_name, self.local_repo.name,
+                                             prefix="file://")
 
     def tearDown(self):
         super().tearDown()
@@ -258,7 +257,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     def test_prep_butler(self):
         """Test that the butler has all necessary data for the next visit.
         """
-        self.interface.prep_butler(self.next_visit)
+        self.interface.prep_butler()
 
         # These shards were identified by plotting the objects in each shard
         # on-sky and overplotting the detector corners.
@@ -274,15 +273,15 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         in the local butler" problem that's related to the "can't register
         the skymap in init" problem.
         """
-        self.interface.prep_butler(self.next_visit)
+        self.interface.prep_butler()
 
         # Second visit with everything same except group.
         second_visit = dataclasses.replace(self.next_visit, groupId=str(int(self.next_visit.groupId) + 1))
-        second_interface = MiddlewareInterface(self.central_butler, self.input_data, instname,
+        second_interface = MiddlewareInterface(self.central_butler, self.input_data, second_visit,
                                                skymap_name, self.local_repo.name,
                                                prefix="file://")
 
-        second_interface.prep_butler(self.next_visit)
+        second_interface.prep_butler()
         expected_shards = {157394, 157401, 157405}
         self._check_imports(second_interface.butler, detector=56, expected_shards=expected_shards)
 
@@ -295,15 +294,15 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                           position=[self.next_visit.position[0] + 0.2,
                                                     self.next_visit.position[1] - 1.2],
                                           )
-        third_interface = MiddlewareInterface(self.central_butler, self.input_data, instname,
+        third_interface = MiddlewareInterface(self.central_butler, self.input_data, third_visit,
                                               skymap_name, self.local_repo.name,
                                               prefix="file://")
-        third_interface.prep_butler(third_visit)
+        third_interface.prep_butler()
         expected_shards.update({157393, 157395})
         self._check_imports(third_interface.butler, detector=5, expected_shards=expected_shards)
 
     def test_ingest_image(self):
-        self.interface.prep_butler(self.next_visit)  # Ensure raw collections exist.
+        self.interface.prep_butler()  # Ensure raw collections exist.
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = fake_file_data(filepath,
@@ -312,7 +311,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(self.next_visit, filename)
+            self.interface.ingest_image(filename)
 
             datasets = list(self.interface.butler.registry.queryDatasets('raw',
                                                                          collections=[f'{instname}/raw/all']))
@@ -331,7 +330,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         through ingest_image(), we'll want to have a test of "missing file
         ingestion", and this can serve as a starting point.
         """
-        self.interface.prep_butler(self.next_visit)  # Ensure raw collections exist.
+        self.interface.prep_butler()  # Ensure raw collections exist.
         filename = "nonexistentImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = fake_file_data(filepath,
@@ -341,7 +340,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock, \
                 self.assertRaisesRegex(FileNotFoundError, "Resource at .* does not exist"):
             mock.return_value = file_data
-            self.interface.ingest_image(self.next_visit, filename)
+            self.interface.ingest_image(filename)
         # There should not be any raw files in the registry.
         datasets = list(self.interface.butler.registry.queryDatasets('raw',
                                                                      collections=[f'{instname}/raw/all']))
@@ -353,7 +352,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         are all zeroed out.
         """
         # Have to setup the data so that we can create the pipeline executor.
-        self.interface.prep_butler(self.next_visit)
+        self.interface.prep_butler()
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = fake_file_data(filepath,
@@ -362,7 +361,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(self.next_visit, filename)
+            self.interface.ingest_image(filename)
 
         with unittest.mock.patch(
                 "activator.middleware_interface.SeparablePipelineExecutor.pre_execute_qgraph") \
@@ -370,7 +369,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
              unittest.mock.patch("activator.middleware_interface.SeparablePipelineExecutor.run_pipeline") \
                 as mock_run:
             with self.assertLogs(self.logger_name, level="INFO") as logs:
-                self.interface.run_pipeline(self.next_visit, {1})
+                self.interface.run_pipeline({1})
         mock_preexec.assert_called_once()
         # Pre-execution may have other arguments as needed; no requirement either way.
         self.assertEqual(mock_preexec.call_args.kwargs["register_dataset_types"], True)
@@ -384,7 +383,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         (because the exposure ids are wrong), raises.
         """
         # Have to setup the data so that we can create the pipeline executor.
-        self.interface.prep_butler(self.next_visit)
+        self.interface.prep_butler()
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = fake_file_data(filepath,
@@ -393,19 +392,19 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(self.next_visit, filename)
+            self.interface.ingest_image(filename)
 
         with self.assertRaisesRegex(RuntimeError, "No data to process"):
-            self.interface.run_pipeline(self.next_visit, {2})
+            self.interface.run_pipeline({2})
 
     def test_get_output_run(self):
         for date in [datetime.date.today(), datetime.datetime.today()]:
-            out_run = self.interface._get_output_run(self.next_visit, date)
+            out_run = self.interface._get_output_run(date)
             self.assertEqual(out_run,
                              f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
                              "/ApPipe/prompt-proto-service-042"
                              )
-            init_run = self.interface._get_init_output_run(self.next_visit, date)
+            init_run = self.interface._get_init_output_run(date)
             self.assertEqual(init_run,
                              f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
                              "/ApPipe/prompt-proto-service-042"
@@ -443,7 +442,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         cat = lsst.afw.table.SourceCatalog()
         raw_collection = self.interface.instrument.makeDefaultRawIngestRunName()
         butler.registry.registerCollection(raw_collection, CollectionType.RUN)
-        out_collection = self.interface._get_output_run(self.next_visit)
+        out_collection = self.interface._get_output_run()
         butler.registry.registerCollection(out_collection, CollectionType.RUN)
         chain = "generic-chain"
         butler.registry.registerCollection(chain, CollectionType.CHAINED)
@@ -456,7 +455,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self._assert_in_collection(butler, "*", "src", processed_data_id)
         self._assert_in_collection(butler, "*", "calexp", processed_data_id)
 
-        self.interface.clean_local_repo(self.next_visit, {raw_data_id["exposure"]})
+        self.interface.clean_local_repo({raw_data_id["exposure"]})
         self._assert_not_in_collection(butler, "*", "raw", raw_data_id)
         self._assert_not_in_collection(butler, "*", "src", processed_data_id)
         self._assert_not_in_collection(butler, "*", "calexp", processed_data_id)
@@ -620,7 +619,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                 skymap=skymap_name,
                                 collections=[f"{instname}/defaults"],
                                 writeable=True)
-        instrument = "lsst.obs.decam.DarkEnergyCamera"
         data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.input_data = os.path.join(data_dir, "input_data")
 
@@ -653,10 +651,10 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.logger_name = "lsst.activator.middleware_interface"
 
         # Populate repository.
-        self.interface = MiddlewareInterface(central_butler, self.input_data, instrument,
+        self.interface = MiddlewareInterface(central_butler, self.input_data, self.next_visit,
                                              skymap_name, local_repo.name,
                                              prefix="file://")
-        self.interface.prep_butler(self.next_visit)
+        self.interface.prep_butler()
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         self.raw_data_id, file_data = fake_file_data(filepath,
@@ -669,16 +667,16 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                                                self.interface.butler.dimensions,
                                                                self.interface.instrument,
                                                                self.second_visit)
-        self.second_interface = MiddlewareInterface(central_butler, self.input_data, instrument,
+        self.second_interface = MiddlewareInterface(central_butler, self.input_data, self.second_visit,
                                                     skymap_name, local_repo.name,
                                                     prefix="file://")
 
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(self.next_visit, filename)
+            self.interface.ingest_image(filename)
         with unittest.mock.patch.object(self.second_interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = second_file_data
-            self.second_interface.ingest_image(self.second_visit, filename)
+            self.second_interface.ingest_image(filename)
         self.interface.define_visits.run([self.raw_data_id])
         self.second_interface.define_visits.run([self.second_data_id])
 
@@ -688,9 +686,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         """Create a mock pipeline execution that stores a calexp for self.raw_data_id.
         """
         exp = lsst.afw.image.ExposureF(20, 20)
-        run1 = self.interface._prep_collections(self.next_visit)
+        run1 = self.interface._prep_collections()
+        run2 = self.second_interface._prep_collections()
         self.processed_data_id = {(k if k != "exposure" else "visit"): v for k, v in self.raw_data_id.items()}
-        run2 = self.second_interface._prep_collections(self.second_visit)
         self.second_processed_data_id = {(k if k != "exposure" else "visit"): v
                                          for k, v in self.second_data_id.items()}
         # Dataset types defined for local Butler on pipeline run, but no
@@ -715,7 +713,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         central_butler.registry.registerCollection("emptyrun", CollectionType.RUN)
         _prepend_collection(central_butler, "refcats", ["emptyrun"])
 
-        self.interface.prep_butler(self.next_visit)
+        self.interface.prep_butler()
 
         self.assertEqual(
             self._count_datasets(self.interface.butler, "gaia", f"{instname}/defaults"),
@@ -725,7 +723,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
             self.interface.butler.registry.queryCollections("refcats", flattenChains=True))
 
     def test_export_outputs(self):
-        self.interface.export_outputs(self.next_visit, {self.raw_data_id["exposure"]})
+        self.interface.export_outputs({self.raw_data_id["exposure"]})
 
         central_butler = Butler(self.central_repo.name, writeable=False)
         raw_collection = f"{instname}/raw/all"
@@ -749,18 +747,13 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
             self._count_datasets(central_butler, ["raw", "calexp"], f"{instname}/defaults"),
             0)
 
-    def test_export_outputs_bad_visit(self):
-        bad_visit = dataclasses.replace(self.next_visit, detector=88)
-        with self.assertRaises(ValueError):
-            self.interface.export_outputs(bad_visit, {self.raw_data_id["exposure"]})
-
     def test_export_outputs_bad_exposure(self):
         with self.assertRaises(ValueError):
-            self.interface.export_outputs(self.next_visit, {88})
+            self.interface.export_outputs({88})
 
     def test_export_outputs_retry(self):
-        self.interface.export_outputs(self.next_visit, {self.raw_data_id["exposure"]})
-        self.second_interface.export_outputs(self.second_visit, {self.second_data_id["exposure"]})
+        self.interface.export_outputs({self.raw_data_id["exposure"]})
+        self.second_interface.export_outputs({self.second_data_id["exposure"]})
 
         central_butler = Butler(self.central_repo.name, writeable=False)
         raw_collection = f"{instname}/raw/all"


### PR DESCRIPTION
This PR fixes two bugs in how the output run was defined, one where the run would be timestamped with the pod boot date rather than the processing date, and one where the same processing could try to use different runs. In the course of fixing the latter bug, I've reorganized how `MiddlewareInterface` handles visits and runs; they are now all initialized at `__init__` time, greatly simplifying other methods.