### PR TITLE
DM-39188: Export raws only if they are not already in the central repo

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -759,7 +759,7 @@ class MiddlewareInterface:
                   f"detector {self.visit.detector} of {exposure_ids}.")
 
     def export_outputs(self, exposure_ids: set[int]) -> None:
-        """Copy raws and pipeline outputs from processing a set of images back
+        """Copy pipeline outputs from processing a set of images back
         to the central Butler.
 
         Parameters
@@ -767,11 +767,6 @@ class MiddlewareInterface:
         exposure_ids : `set` [`int`]
             Identifiers of the exposures that were processed.
         """
-        # TODO: this method will not be responsible for raws after DM-36051.
-        self._export_subset(exposure_ids, "raw",
-                            in_collections=self.instrument.makeDefaultRawIngestRunName(),
-                            )
-
         self._export_subset(exposure_ids,
                             # TODO: find a way to merge datasets like *_config
                             # or *_schema that are duplicated across multiple

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -743,14 +743,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.interface.export_outputs({self.raw_data_id["exposure"]})
 
         central_butler = Butler(self.central_repo.name, writeable=False)
-        raw_collection = f"{instname}/raw/all"
         date = datetime.datetime.now(datetime.timezone.utc)
         export_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
                             "/ApPipe/prompt-proto-service-042"
-        self.assertEqual(self._count_datasets(central_butler, "raw", raw_collection), 1)
-        self.assertEqual(
-            self._count_datasets_with_id(central_butler, "raw", raw_collection, self.raw_data_id),
-            1)
         self.assertEqual(self._count_datasets(central_butler, "calexp", export_collection), 1)
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "calexp", export_collection, self.processed_data_id),
@@ -773,17 +768,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.second_interface.export_outputs({self.second_data_id["exposure"]})
 
         central_butler = Butler(self.central_repo.name, writeable=False)
-        raw_collection = f"{instname}/raw/all"
         date = datetime.datetime.now(datetime.timezone.utc)
         export_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
                             "/ApPipe/prompt-proto-service-042"
-        self.assertEqual(self._count_datasets(central_butler, "raw", raw_collection), 2)
-        self.assertEqual(
-            self._count_datasets_with_id(central_butler, "raw", raw_collection, self.raw_data_id),
-            1)
-        self.assertEqual(
-            self._count_datasets_with_id(central_butler, "raw", raw_collection, self.second_data_id),
-            1)
         self.assertEqual(self._count_datasets(central_butler, "calexp", export_collection), 2)
         self.assertEqual(
             self._count_datasets_with_id(central_butler, "calexp", export_collection, self.processed_data_id),


### PR DESCRIPTION
I hesitate about this because adding a query with the central repo means time spent waiting for the database query, and it probably won't scale well.  If we can agree just don't export raws in all cases, it seems better just to remove it.  Do we really want to wait for [DM-36051](https://jira.lsstcorp.org/browse/DM-36051).? 