### PR TITLE
DM-38225: Intermittent init-output collision in Prompt Processing

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -314,12 +314,14 @@ def next_visit_handler() -> Tuple[str, int]:
             if len(expid_set) < expected_visit.nimages:
                 _log.warning(f"Processing {len(expid_set)} snaps, expected {expected_visit.nimages}.")
             _log.info(f"Running pipeline on {expected_visit}.")
-            mwi.run_pipeline(expid_set)
-            # TODO: broadcast alerts here
-            # TODO: call export_outputs on success or permanent failure in DM-34141
-            mwi.export_outputs(expid_set)
-            # Clean only if export successful.
-            mwi.clean_local_repo(expid_set)
+            try:
+                mwi.run_pipeline(expid_set)
+                # TODO: broadcast alerts here
+                # TODO: call export_outputs on success or permanent failure in DM-34141
+                mwi.export_outputs(expid_set)
+            finally:
+                # TODO: run_pipeline requires a clean run until DM-38041.
+                mwi.clean_local_repo(expid_set)
             return "Pipeline executed", 200
         else:
             _log.error(f"Timed out waiting for images for {expected_visit}.")

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -751,6 +751,7 @@ class MiddlewareInterface:
             raise RuntimeError("No data to process.")
         # If this is a fresh (local) repo, then types like calexp,
         # *Diff_diaSrcTable, etc. have not been registered.
+        # TODO: after DM-38041, move pre-execution to one-time repo setup.
         executor.pre_execute_qgraph(qgraph, register_dataset_types=True, save_init_outputs=True)
         _log.info(f"Running '{pipeline._pipelineIR.description}' on {where}")
         executor.run_pipeline(qgraph)


### PR DESCRIPTION
`MiddlewareInterface.run_pipeline` creates pipeline init-outputs, which can conflict with previous init-outputs if `clean_local_repo` has not been called. Requiring that `clean_local_repo` be called if `run_pipeline` is called prevents the conflict.

An alternative would be to construct the `SeparablePipelineExecutor` with `clobber_output=True`. However, this change may have unintended side effects, especially since the exact behavior of execution flags is subject to change.