### PR TITLE
DM-39678: Allow Prompt Prototype to be configured with no pipeline

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -241,6 +241,10 @@ def next_visit_handler() -> Tuple[str, int]:
             return f"Bad Request: {msg}", 400
         assert expected_visit.instrument == instrument_name, \
             f"Expected {instrument_name}, received {expected_visit.instrument}."
+        if pipelines.get_pipeline_file(expected_visit) is None:
+            _log.info(f"No pipeline configured for {expected_visit}, skipping.")
+            return "No pipeline configured for the received visit.", 422
+
         expid_set = set()
 
         # Create a fresh MiddlewareInterface object to avoid accidental

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -54,7 +54,7 @@ class BareVisit:
         """Return a short string that represents the visit but does not
         include complete metadata.
         """
-        return f"(groupId={self.groupId}, salIndex={self.salIndex})"
+        return f"(groupId={self.groupId}, survey={self.survey}, salIndex={self.salIndex})"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -67,7 +67,8 @@ class FannedOutVisit(BareVisit):
         """Return a short string that disambiguates the visit but does not
         include "metadata" fields.
         """
-        return f"(instrument={self.instrument}, groupId={self.groupId}, detector={self.detector})"
+        return f"(instrument={self.instrument}, groupId={self.groupId}, survey={self.survey} " \
+               f"detector={self.detector})"
 
     def get_bare_visit(self):
         """Return visit-level info as a dict"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,6 +108,16 @@ class PipelinesConfigTest(unittest.TestCase):
             os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipe lines", "Isr.yaml"))
         )
 
+    def test_none(self):
+        config = PipelinesConfig('(survey="TestSurvey")=None shall pass/pipelines/SingleFrame.yaml '
+                                 '(survey="Camera Test")=None '
+                                 )
+        self.assertEqual(
+            config.get_pipeline_file(self.visit),
+            os.path.normpath(os.path.join("None shall pass", "pipelines", "SingleFrame.yaml"))
+        )
+        self.assertIsNone(config.get_pipeline_file(dataclasses.replace(self.visit, survey="Camera Test")))
+
     def test_nomatch(self):
         config = PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml '
                                  '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -749,7 +749,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.second_interface.export_outputs({self.second_data_id["exposure"]})
 
         central_butler = Butler(self.central_repo.name, writeable=False)
-        date = datetime.datetime.now(datetime.timezone.utc)
+        date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
         export_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
                             "/ApPipe/prompt-proto-service-042"
         self.assertEqual(self._count_datasets(central_butler, "calexp", export_collection), 2)
@@ -778,7 +778,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.second_interface.export_outputs({self.second_data_id["exposure"]})
 
         central_butler = Butler(self.central_repo.name, writeable=False)
-        date = datetime.datetime.now(datetime.timezone.utc)
+        date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
         export_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
                             "/ApPipe/prompt-proto-service-042"
         self.assertEqual(self._count_datasets(central_butler, "calexp", export_collection), 2)


### PR DESCRIPTION
This PR adds some logic that lets us skip Prompt Processing execution for specific types of visits. This is mainly intended for spectroscopic observations taken with LATISS.