### PR TITLE
DM-39655: Use a list of "fallback" pipelines in Prompt Processing

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -214,6 +214,8 @@ All service configuration is in ``prompt-proto-service.yaml``.
 It includes the following required environment variables:
 
 * RUBIN_INSTRUMENT: the "short" instrument name
+* PIPELINES_CONFIG: a machine-readable string describing which pipeline(s) should be run for which visits.
+  Notation is complex and still in flux; see :file:`../python/activator/config.py` for current documentation and examples.
 * PUBSUB_VERIFICATION_TOKEN: choose an arbitrary string matching the Pub/Sub endpoint URL below.
   This variable is currently unused and may be removed in the future.
 * IMAGE_BUCKET: bucket containing raw images

--- a/pipelines/LATISS/Isr.yaml
+++ b/pipelines/LATISS/Isr.yaml
@@ -1,0 +1,6 @@
+description: ISR-only pipeline specialized for LATISS
+
+imports:
+  - location: $PROMPT_PROTOTYPE_DIR/pipelines/LATISS/ApPipe.yaml
+    include:
+      - isr

--- a/pipelines/LATISS/SingleFrame.yaml
+++ b/pipelines/LATISS/SingleFrame.yaml
@@ -1,0 +1,6 @@
+description: Single-frame pipeline specialized for LATISS
+
+imports:
+  - location: $PROMPT_PROTOTYPE_DIR/pipelines/LATISS/ApPipe.yaml
+    include:
+      - processCcd

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -244,7 +244,7 @@ def next_visit_handler() -> Tuple[str, int]:
             return f"Bad Request: {msg}", 400
         assert expected_visit.instrument == instrument_name, \
             f"Expected {instrument_name}, received {expected_visit.instrument}."
-        if pipelines.get_pipeline_file(expected_visit) is None:
+        if not pipelines.get_pipeline_files(expected_visit):
             _log.info(f"No pipeline configured for {expected_visit}, skipping.")
             return "No pipeline configured for the received visit.", 422
 

--- a/python/activator/config.py
+++ b/python/activator/config.py
@@ -99,8 +99,8 @@ class PipelinesConfig:
 
         Returns
         -------
-        config : mapping [`str`, `str` or `None`]
-            A mapping from the survey type to the pipeline to run for that
+        config : mapping [`str`, `list` [`str`]]
+            A mapping from the survey type to the pipeline(s) to run for that
             survey. A more complex key or container type may be needed in the
             future, if other pipeline selection criteria are added.
 
@@ -117,7 +117,7 @@ class PipelinesConfig:
         pos = 0
         match = node.match(config, pos)
         while match:
-            items[match['survey']] = match['filename'] if match['filename'].lower() != "none" else None
+            items[match['survey']] = [match['filename']] if match['filename'].lower() != "none" else []
 
             pos = match.end()
             match = node.match(config, pos)
@@ -126,7 +126,7 @@ class PipelinesConfig:
 
         return items
 
-    def get_pipeline_file(self, visit: FannedOutVisit) -> str:
+    def get_pipeline_files(self, visit: FannedOutVisit) -> str:
         """Identify the pipeline to be run, based on the provided visit.
 
         Parameters
@@ -136,15 +136,12 @@ class PipelinesConfig:
 
         Returns
         -------
-        pipeline : `str` or `None`
-            A path to a configured pipeline file. A value of `None` means that
-            *no* pipeline should be run on this visit.
+        pipeline : `list` [`str`]
+            Path(s) to the configured pipeline file(s). An empty list means
+            that *no* pipeline should be run on this visit.
         """
         try:
-            value = self._mapping[visit.survey]
+            values = self._mapping[visit.survey]
         except KeyError as e:
             raise RuntimeError(f"Unsupported survey: {visit.survey}") from e
-        if value is not None:
-            return os.path.expandvars(value)
-        else:
-            return value
+        return [os.path.expandvars(path) for path in values]

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -224,7 +224,7 @@ class MiddlewareInterface:
         self.init_output_run = self._get_init_output_run()
         self.output_run = self._get_output_run()
 
-        self._init_local_butler(local_repo, [self.output_collection], self.output_run)
+        self._init_local_butler(local_repo, [self.output_collection], None)
         self._prep_collections()
         self._init_ingester()
         self._init_visit_definer()

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -480,8 +480,6 @@ class MiddlewareInterface:
         # TODO: do we need to have the coadd name used in the pipeline
         # specified as a class kwarg, so that we only load one here?
         # TODO: alternately, we need to extract it from the pipeline? (best?)
-        # TODO: alternately, can we just assume that there is exactly
-        # one coadd type in the central butler?
         try:
             templates = set(_filter_datasets(
                 self.central_butler, self.butler,

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -186,8 +186,8 @@ class MiddlewareInterface:
     # self.visit, self.instrument, self.camera, self.skymap, self._deployment
     #   do not change after __init__.
     # self.butler defaults to a chained collection named
-    #   self.output_collection, which contains zero or more output runs
-    #   and all pipeline inputs, in that order. However, self.butler is not
+    #   self.output_collection, which contains all pipeline inputs.
+    #   However, self.butler is not
     #   guaranteed to contain concrete data, or even the dimensions
     #   corresponding to self.camera and self.skymap. Do not assume that
     #   self.butler is the only Butler pointing to the local repo.
@@ -619,9 +619,6 @@ class MiddlewareInterface:
         self.butler.registry.refresh()
         self.butler.registry.registerCollection(self.init_output_run, CollectionType.RUN)
         self.butler.registry.registerCollection(self.output_run, CollectionType.RUN)
-        # As of Feb 2023, this moves output_run to the front of the chain if
-        # it's already present, but this behavior cannot be relied upon.
-        _prepend_collection(self.butler, self.output_collection, [self.output_run, self.init_output_run])
 
     def _get_pipeline_file(self) -> str:
         """Identify the pipeline to be run, based on the configured instrument

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -192,8 +192,7 @@ class MiddlewareInterface:
     #   corresponding to self.camera and self.skymap. Do not assume that
     #   self.butler is the only Butler pointing to the local repo.
     # self.init_output_run and self.output_run do not change after __init__.
-    #   They need not exist in the local repo, but if they do, they are members
-    #   of self.output_collection.
+    #   They need not exist in the local repo.
 
     def __init__(self, central_butler: Butler, image_bucket: str, visit: FannedOutVisit,
                  pipelines: PipelinesConfig, skymap: str, local_repo: str,
@@ -739,7 +738,13 @@ class MiddlewareInterface:
             " and visit_system = 0"
         )
         pipeline = self._prep_pipeline()
-        executor = SeparablePipelineExecutor(self.butler, clobber_output=False, skip_existing_in=None)
+        executor = SeparablePipelineExecutor(
+            Butler(butler=self.butler,
+                   collections=[self.output_run, self.init_output_run] + list(self.butler.collections),
+                   run=self.output_run),
+            clobber_output=False,
+            skip_existing_in=None
+        )
         qgraph = executor.make_quantum_graph(pipeline, where=where)
         if len(qgraph) == 0:
             # TODO: a good place for a custom exception?

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -634,7 +634,7 @@ class MiddlewareInterface:
             A sequence of paths to a configured pipeline file, in order from
             most preferred to least preferred.
         """
-        return [self.pipelines.get_pipeline_file(self.visit)]
+        return self.pipelines.get_pipeline_files(self.visit)
 
     def _prep_pipeline(self, pipeline_file) -> lsst.pipe.base.Pipeline:
         """Setup the pipeline to be run, based on the configured instrument and

--- a/tests/data/ISR.yaml
+++ b/tests/data/ISR.yaml
@@ -1,0 +1,6 @@
+description: Test pipeline consisting only of ISR.
+
+imports:
+  - location: $PROMPT_PROTOTYPE_DIR/tests/data/ApPipe.yaml
+    include:
+      - isr

--- a/tests/data/SingleFrame.yaml
+++ b/tests/data/SingleFrame.yaml
@@ -1,0 +1,8 @@
+description: Test pipeline consisting only of single-frame steps.
+
+imports:
+  - location: $PROMPT_PROTOTYPE_DIR/tests/data/ApPipe.yaml
+    include:
+      - isr
+      - characterizeImage
+      - calibrate

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,3 +179,11 @@ class PipelinesConfigTest(unittest.TestCase):
             PipelinesConfig('[/etc/pipelines/SingleFrame.yaml] '
                             '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                             )
+
+    def test_duplicates(self):
+        with self.assertRaises(ValueError):
+            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/ApPipe.yaml,'
+                            '                       ${AP_PIPE_DIR}/pipelines/ApPipe.yaml]')
+        with self.assertRaises(ValueError):
+            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/ApPipe.yaml,'
+                            '                       /etc/pipelines/ApPipe.yaml#isr]')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,8 +59,8 @@ class PipelinesConfigTest(unittest.TestCase):
         config = PipelinesConfig(
             ' (survey="TestSurvey")=${PROMPT_PROTOTYPE_DIR}/pipelines/NotACam/ApPipe.yaml')
         self.assertEqual(
-            config.get_pipeline_file(self.visit),
-            os.path.normpath(os.path.join(TESTDIR, "..", "pipelines", "NotACam", "ApPipe.yaml"))
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join(TESTDIR, "..", "pipelines", "NotACam", "ApPipe.yaml"))]
         )
 
     def test_selection(self):
@@ -69,16 +69,16 @@ class PipelinesConfigTest(unittest.TestCase):
                                  '(survey="")=Default.yaml '
                                  )
         self.assertEqual(
-            config.get_pipeline_file(self.visit),
-            os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
         )
         self.assertEqual(
-            config.get_pipeline_file(dataclasses.replace(self.visit, survey="CameraTest")),
-            os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="CameraTest")),
+            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
         )
         self.assertEqual(
-            config.get_pipeline_file(dataclasses.replace(self.visit, survey="")),
-            "Default.yaml"
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="")),
+            ["Default.yaml"]
         )
 
     def test_multiline(self):
@@ -87,12 +87,12 @@ class PipelinesConfigTest(unittest.TestCase):
                                  '''
                                  )
         self.assertEqual(
-            config.get_pipeline_file(self.visit),
-            os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
         )
         self.assertEqual(
-            config.get_pipeline_file(dataclasses.replace(self.visit, survey="CameraTest")),
-            os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="CameraTest")),
+            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
         )
 
     def test_space(self):
@@ -100,12 +100,12 @@ class PipelinesConfigTest(unittest.TestCase):
                                  '(survey="Camera Test")=${AP_PIPE_DIR}/pipe lines/Isr.yaml '
                                  )
         self.assertEqual(
-            config.get_pipeline_file(self.visit),
-            os.path.normpath(os.path.join("/dir with space", "pipelines", "SingleFrame.yaml"))
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join("/dir with space", "pipelines", "SingleFrame.yaml"))]
         )
         self.assertEqual(
-            config.get_pipeline_file(dataclasses.replace(self.visit, survey="Camera Test")),
-            os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipe lines", "Isr.yaml"))
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="Camera Test")),
+            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipe lines", "Isr.yaml"))]
         )
 
     def test_none(self):
@@ -113,17 +113,18 @@ class PipelinesConfigTest(unittest.TestCase):
                                  '(survey="Camera Test")=None '
                                  )
         self.assertEqual(
-            config.get_pipeline_file(self.visit),
-            os.path.normpath(os.path.join("None shall pass", "pipelines", "SingleFrame.yaml"))
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join("None shall pass", "pipelines", "SingleFrame.yaml"))]
         )
-        self.assertIsNone(config.get_pipeline_file(dataclasses.replace(self.visit, survey="Camera Test")))
+        self.assertEqual(config.get_pipeline_files(dataclasses.replace(self.visit, survey="Camera Test")),
+                         [])
 
     def test_nomatch(self):
         config = PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml '
                                  '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
                                  )
         with self.assertRaises(RuntimeError):
-            config.get_pipeline_file(dataclasses.replace(self.visit, survey="Surprise"))
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="Surprise"))
 
     def test_empty(self):
         with self.assertRaises(ValueError):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,16 +57,16 @@ class PipelinesConfigTest(unittest.TestCase):
 
     def test_main_survey(self):
         config = PipelinesConfig(
-            ' (survey="TestSurvey")=${PROMPT_PROTOTYPE_DIR}/pipelines/NotACam/ApPipe.yaml')
+            ' (survey="TestSurvey")=[${PROMPT_PROTOTYPE_DIR}/pipelines/NotACam/ApPipe.yaml]')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join(TESTDIR, "..", "pipelines", "NotACam", "ApPipe.yaml"))]
         )
 
     def test_selection(self):
-        config = PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml '
-                                 '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
-                                 '(survey="")=Default.yaml '
+        config = PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml] '
+                                 '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
+                                 '(survey="")=[Default.yaml] '
                                  )
         self.assertEqual(
             config.get_pipeline_files(self.visit),
@@ -82,8 +82,8 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_multiline(self):
-        config = PipelinesConfig('''(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml
-                                 (survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml
+        config = PipelinesConfig('''(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml]
+                                 (survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml]
                                  '''
                                  )
         self.assertEqual(
@@ -95,9 +95,19 @@ class PipelinesConfigTest(unittest.TestCase):
             [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
         )
 
+    def test_fallback(self):
+        config = PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml, '
+                                 '                       ${AP_PIPE_DIR}/pipelines/Isr.yaml]'
+                                 )
+        self.assertEqual(
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml")),
+             os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
+        )
+
     def test_space(self):
-        config = PipelinesConfig('(survey="TestSurvey")=/dir with space/pipelines/SingleFrame.yaml '
-                                 '(survey="Camera Test")=${AP_PIPE_DIR}/pipe lines/Isr.yaml '
+        config = PipelinesConfig('(survey="TestSurvey")=[/dir with space/pipelines/SingleFrame.yaml] '
+                                 '(survey="Camera Test")=[${AP_PIPE_DIR}/pipe lines/Isr.yaml] '
                                  )
         self.assertEqual(
             config.get_pipeline_files(self.visit),
@@ -109,8 +119,9 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_none(self):
-        config = PipelinesConfig('(survey="TestSurvey")=None shall pass/pipelines/SingleFrame.yaml '
+        config = PipelinesConfig('(survey="TestSurvey")=[None shall pass/pipelines/SingleFrame.yaml] '
                                  '(survey="Camera Test")=None '
+                                 '(survey="CameraTest")=[] '
                                  )
         self.assertEqual(
             config.get_pipeline_files(self.visit),
@@ -118,10 +129,12 @@ class PipelinesConfigTest(unittest.TestCase):
         )
         self.assertEqual(config.get_pipeline_files(dataclasses.replace(self.visit, survey="Camera Test")),
                          [])
+        self.assertEqual(config.get_pipeline_files(dataclasses.replace(self.visit, survey="CameraTest")),
+                         [])
 
     def test_nomatch(self):
-        config = PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml '
-                                 '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
+        config = PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml] '
+                                 '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                                  )
         with self.assertRaises(RuntimeError):
             config.get_pipeline_files(dataclasses.replace(self.visit, survey="Surprise"))
@@ -134,39 +147,35 @@ class PipelinesConfigTest(unittest.TestCase):
 
     def test_commas(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml, '
-                            '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
+            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml], '
+                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                             )
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml,'
-                            '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
+            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml],'
+                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                             )
 
     def test_unlabeled(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml, '
-                            '("CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
+            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml], '
+                            '("CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                             )
 
     def test_oddlabel(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(reason="TestSurvey")=/etc/pipelines/SingleFrame.yaml')
+            PipelinesConfig('(reason="TestSurvey")=[/etc/pipelines/SingleFrame.yaml]')
 
     def test_nospace(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=/etc/pipelines/SingleFrame.yaml'
-                            '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml'
-                            )
-        with self.assertRaises(ValueError):
-            PipelinesConfig('/etc/pipelines/SingleFrame.yaml'
-                            '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml'
+            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml]'
+                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml]'
                             )
 
     def test_noequal(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('/etc/pipelines/SingleFrame.yaml')
+            PipelinesConfig('[/etc/pipelines/SingleFrame.yaml]')
 
         with self.assertRaises(ValueError):
-            PipelinesConfig('/etc/pipelines/SingleFrame.yaml '
-                            '(survey="CameraTest")=${AP_PIPE_DIR}/pipelines/Isr.yaml '
+            PipelinesConfig('[/etc/pipelines/SingleFrame.yaml] '
+                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                             )

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -402,13 +402,14 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             self.interface.run_pipeline({2})
 
     def test_get_output_run(self):
+        filename = "ApPipe.yaml"
         for date in [datetime.date.today(), datetime.datetime.today()]:
-            out_run = self.interface._get_output_run(date)
+            out_run = self.interface._get_output_run(filename, date)
             self.assertEqual(out_run,
                              f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
                              "/ApPipe/prompt-proto-service-042"
                              )
-            init_run = self.interface._get_init_output_run(date)
+            init_run = self.interface._get_init_output_run(filename, date)
             self.assertEqual(init_run,
                              f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
                              "/ApPipe/prompt-proto-service-042"
@@ -427,10 +428,11 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 else:
                     return utc.replace(tzinfo=None)
 
+        filename = "ApPipe.yaml"
         with unittest.mock.patch("datetime.datetime", MockDatetime):
-            out_run = self.interface._get_output_run()
+            out_run = self.interface._get_output_run(filename)
             self.assertIn("output-2023-03-14", out_run)
-            init_run = self.interface._get_init_output_run()
+            init_run = self.interface._get_init_output_run(filename)
             self.assertIn("output-2023-03-14", init_run)
 
     def _assert_in_collection(self, butler, collection, dataset_type, data_id):
@@ -465,7 +467,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         cat = lsst.afw.table.SourceCatalog()
         raw_collection = self.interface.instrument.makeDefaultRawIngestRunName()
         butler.registry.registerCollection(raw_collection, CollectionType.RUN)
-        out_collection = self.interface._get_output_run()
+        out_collection = self.interface._get_output_run("ApPipe.yaml")
         butler.registry.registerCollection(out_collection, CollectionType.RUN)
         chain = "generic-chain"
         butler.registry.registerCollection(chain, CollectionType.CHAINED)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -129,8 +129,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     def setUp(self):
         data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.central_repo = os.path.join(data_dir, "central_repo")
+        self.umbrella = f"{instname}/defaults"
         self.central_butler = Butler(self.central_repo,
-                                     collections=[f"{instname}/defaults"],
+                                     collections=[self.umbrella],
                                      writeable=False,
                                      inferDefaults=False)
         self.input_data = os.path.join(data_dir, "input_data")
@@ -200,7 +201,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that the butler instance is properly configured.
         instruments = list(self.interface.butler.registry.queryDimensionRecords("instrument"))
         self.assertEqual(instname, instruments[0].name)
-        self.assertEqual(set(self.interface.butler.collections), {self.interface.output_collection})
+        self.assertEqual(set(self.interface.butler.collections), {self.umbrella})
 
         # Check that the ingester is properly configured.
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)
@@ -218,7 +219,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             butler.exists("skyMap",
                           skymap=skymap_name,
                           full_check=True,
-                          collections=self.interface.output_collection)
+                          collections=self.umbrella)
         )
 
         # check that we got appropriate refcat shards
@@ -233,7 +234,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                           full_check=True,
                           # TODO: Have to use the exact run collection, because we can't
                           # query by validity range.
-                          # collections=self.interface.output_collection)
+                          # collections=self.umbrella)
                           collections="DECam/calib/20150218T000000Z")
         )
         self.assertTrue(
@@ -242,7 +243,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                           full_check=True,
                           # TODO: Have to use the exact run collection, because we can't
                           # query by validity range.
-                          # collections=self.interface.output_collection)
+                          # collections=self.umbrella)
                           collections="DECam/calib/20150218T000000Z")
         )
 
@@ -254,7 +255,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 butler.exists('deepCoadd', tract=0, patch=patch, band="g",
                               skymap=skymap_name,
                               full_check=True,
-                              collections=self.interface.output_collection)
+                              collections=self.umbrella)
             )
 
     def test_prep_butler(self):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -51,8 +51,13 @@ instname = "DECam"
 filter = "g DECam SDSS c0001 4720.0 1520.0"
 # The skymap name used in the test repo.
 skymap_name = "deepCoadd_skyMap"
-# A pipelines config that returns the test pipeline.
-pipelines = PipelinesConfig('(survey="SURVEY")=${PROMPT_PROTOTYPE_DIR}/tests/data/ApPipe.yaml')
+# A pipelines config that returns the test pipelines.
+# Unless a test imposes otherwise, the first pipeline should run, and
+# the second should not be attempted.
+pipelines = PipelinesConfig('''(survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/tests/data/ApPipe.yaml,
+                                                  ${PROMPT_PROTOTYPE_DIR}/tests/data/SingleFrame.yaml]
+                            '''
+                            )
 
 
 def fake_file_data(filename, dimensions, instrument, visit):
@@ -378,6 +383,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 as mock_run:
             with self.assertLogs(self.logger_name, level="INFO") as logs:
                 self.interface.run_pipeline({1})
+        # Pre-execution and execution should only run once, even if graph
+        # generation is attempted for multiple pipelines.
         mock_preexec.assert_called_once()
         # Pre-execution may have other arguments as needed; no requirement either way.
         self.assertEqual(mock_preexec.call_args.kwargs["register_dataset_types"], True)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -382,8 +382,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.assertIn("End to end Alert Production pipeline specialized for HiTS-2015",
                       "\n".join(logs.output))
 
-    def test_run_pipeline_empty_quantum_graph(self):
-        """Test that running a pipeline that results in an empty quantum graph
+    def test_run_pipeline_bad_visits(self):
+        """Test that running a pipeline that results in bad visit definition
         (because the exposure ids are wrong), raises.
         """
         # Have to setup the data so that we can create the pipeline executor.


### PR DESCRIPTION
This PR adds support for multiple pipelines that may be attempted for the same visit, in sequence. This required a significant reorganization of `MiddlewareInterface`, moving decisions that depend on the choice of pipeline to as late in the workflow as possible. However, the new code has fewer implicit dependencies, making it more robust to future changes.