### PR TITLE
DM-40210: Guard against future ap_pipe changes

### DIFF
--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - '.github/workflows/build-service.yml'
+      - 'pipelines/**'
       - 'python/activator/**'
       - 'Dockerfile.activator'
   pull_request:
     paths:
       - '.github/workflows/build-service.yml'
+      - 'pipelines/**'
       - 'python/activator/**'
       - 'Dockerfile.activator'
   workflow_dispatch:

--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -9,4 +9,4 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
-      doSolarSystemAssociation: false
+      doSolarSystemAssociation: false  # No "known objects" catalog for fake visits

--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -2,10 +2,17 @@ description: End to end Alert Production pipeline specialized for HSC-RC2
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipe.yaml
+    exclude:
+      # TODO: container does not yet support R/B analysis.
+      - rbClassify
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing
 tasks:
+  transformDiaSrcCat:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      doIncludeReliability: False  # TODO: container does not yet support R/B analysis
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -2,6 +2,14 @@ description: Alert Production pipeline specialized for LATISS
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LATISS/ApPipe.yaml
+    exclude:
+      # TODO: container does not yet support R/B analysis.
+      - rbClassify
 parameters:
   # Only have deep templates in the central repo
   coaddName: deep
+tasks:
+  transformDiaSrcCat:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      doIncludeReliability: False  # TODO: container does not yet support R/B analysis


### PR DESCRIPTION
This PR adds an exclusion of the `rbClassify` task from the Prompt Processing pipeline, in case it is added to `ap_pipe` in the future (see comments added in lsst/ap_verify#196 for details on the blockers). This will prevent us from accidentally trying to run the task before we are ready for it.