### PR TITLE
DM-40296: Add a timestamp to FannedOutVisit

### DIFF
--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -62,6 +62,7 @@ class FannedOutVisit(BareVisit):
     # Extra information is added by the fan-out service at USDF.
     instrument: str             # short name
     detector: int
+    private_sndStamp: float     # time of visit publication; TAI in unix seconds
 
     def __str__(self):
         """Return a short string that disambiguates the visit but does not
@@ -75,6 +76,7 @@ class FannedOutVisit(BareVisit):
         info = asdict(self)
         info.pop("instrument")
         info.pop("detector")
+        info.pop("private_sndStamp")
         return info
 
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -59,7 +59,7 @@ def process_group(kafka_url, visit_infos, uploader):
     for info in visit_infos:
         group = info.groupId
         n_snaps = info.nimages
-        visit = SummitVisit(**info.get_bare_visit())
+        visit = SummitVisit(**info.get_bare_visit(), private_sndStamp=info.private_sndStamp)
         send_next_visit(kafka_url, group, {visit})
         break
     else:
@@ -133,16 +133,16 @@ def get_samples(bucket, instrument):
     #     upload time, another is to download the blob and actually read
     #     its header.
     hsc_metadata = {
-        59126: {"ra": 149.28531249999997, "dec": 2.935002777777778, "rot": 270.0},
-        59134: {"ra": 149.45749166666664, "dec": 2.926961111111111, "rot": 270.0},
-        59138: {"ra": 149.45739166666664, "dec": 1.4269472222222224, "rot": 270.0},
-        59142: {"ra": 149.4992083333333, "dec": 2.8853, "rot": 270.0},
-        59150: {"ra": 149.96643749999996, "dec": 2.2202916666666668, "rot": 270.0},
-        59152: {"ra": 149.9247333333333, "dec": 2.1577777777777776, "rot": 270.0},
-        59154: {"ra": 150.22329166666663, "dec": 2.238341666666667, "rot": 270.0},
-        59156: {"ra": 150.26497083333334, "dec": 2.1966694444444443, "rot": 270.0},
-        59158: {"ra": 150.30668333333332, "dec": 2.2591888888888887, "rot": 270.0},
-        59160: {"ra": 150.18157499999998, "dec": 2.2800083333333334, "rot": 270.0},
+        59126: {"ra": 149.28531249999997, "dec": 2.935002777777778, "rot": 270.0, "time": 1457332820.0},
+        59134: {"ra": 149.45749166666664, "dec": 2.926961111111111, "rot": 270.0, "time": 1457333685.0},
+        59138: {"ra": 149.45739166666664, "dec": 1.4269472222222224, "rot": 270.0, "time": 1457334125.0},
+        59142: {"ra": 149.4992083333333, "dec": 2.8853, "rot": 270.0, "time": 1457334559.0},
+        59150: {"ra": 149.96643749999996, "dec": 2.2202916666666668, "rot": 270.0, "time": 1457335427.0},
+        59152: {"ra": 149.9247333333333, "dec": 2.1577777777777776, "rot": 270.0, "time": 1457335765.0},
+        59154: {"ra": 150.22329166666663, "dec": 2.238341666666667, "rot": 270.0, "time": 1457336099.0},
+        59156: {"ra": 150.26497083333334, "dec": 2.1966694444444443, "rot": 270.0, "time": 1457336431.0},
+        59158: {"ra": 150.30668333333332, "dec": 2.2591888888888887, "rot": 270.0, "time": 1457336763.0},
+        59160: {"ra": 150.18157499999998, "dec": 2.2800083333333334, "rot": 270.0, "time": 1457337098.0},
     }
 
     # The pre-made raw files are stored with the "unobserved" prefix
@@ -173,6 +173,7 @@ def get_samples(bucket, instrument):
             dome=FannedOutVisit.Dome.OPEN,
             duration=float(EXPOSURE_INTERVAL+SLEW_INTERVAL),
             totalCheckpoints=1,
+            private_sndStamp=hsc_metadata[exp_id]["time"],
         )
         _log.debug(f"File {blob.key} parsed as snap {snap_num} of visit {visit}.")
         if group in result:

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -32,7 +32,8 @@ from lsst.daf.butler import Butler
 
 from activator.raw import get_raw_path
 from activator.visit import SummitVisit
-from tester.utils import get_last_group, make_exposure_id, replace_header_key, send_next_visit
+from tester.utils import get_last_group, make_exposure_id, replace_header_key, send_next_visit, \
+    day_obs_to_unix_utc
 
 
 EXPOSURE_INTERVAL = 18
@@ -153,6 +154,7 @@ def prepare_one_visit(kafka_url, group_id, butler, visit_id):
             dome=SummitVisit.Dome.OPEN,
             duration=float(EXPOSURE_INTERVAL+SLEW_INTERVAL),
             totalCheckpoints=1,
+            private_sndStamp=day_obs_to_unix_utc(data_id.records["exposure"].day_obs),
         )
         send_next_visit(kafka_url, group_id, {visit})
 

--- a/python/tester/utils.py
+++ b/python/tester/utils.py
@@ -21,7 +21,9 @@
 
 __all__ = ["get_last_group", "make_exposure_id", "replace_header_key", "send_next_visit"]
 
+import calendar
 from dataclasses import asdict
+import datetime
 import json
 import logging
 import requests
@@ -202,3 +204,28 @@ def replace_header_key(file, key, value):
     finally:
         # Clean up HDUList object *without* closing ``file``.
         hdus.close(closed=False)
+
+
+def day_obs_to_unix_utc(day_obs):
+    """Create a Unix timestamp for a day_obs.
+
+    Parameters
+    ----------
+    day_obs : `int`
+        An 8-digit integer in the form YYYYMMDD representing the day_obs of an
+        observation.
+
+    Returns
+    -------
+    timestamp : `float`
+        The Unix UTC timestamp corresponding to UTC-4 midnight on day_obs.
+    """
+    year = day_obs // 1_00_00
+    month = (day_obs % 1_00_00) // 1_00
+    day = day_obs % 1_00
+    midnight = datetime.datetime(
+        year, month, day,
+        0, 0, 0,
+        tzinfo=datetime.timezone(-datetime.timedelta(hours=4))
+    ) + datetime.timedelta(days=1)  # Day advances at midnight
+    return calendar.timegm(midnight.utctimetuple())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,7 @@ class PipelinesConfigTest(unittest.TestCase):
             dome=FannedOutVisit.Dome.OPEN,
             duration=35.0,
             totalCheckpoints=1,
+            private_sndStamp=1_674_516_794.0,
         )
 
     def test_main_survey(self):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -162,6 +162,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                          dome=FannedOutVisit.Dome.OPEN,
                                          duration=35.0,
                                          totalCheckpoints=1,
+                                         private_sndStamp=1_674_516_794.0,
                                          )
         self.logger_name = "lsst.activator.middleware_interface"
         self.interface = MiddlewareInterface(self.central_butler, self.input_data, self.next_visit,
@@ -779,6 +780,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                          dome=FannedOutVisit.Dome.OPEN,
                                          duration=35.0,
                                          totalCheckpoints=1,
+                                         private_sndStamp=1_674_516_794.0,
                                          )
         self.logger_name = "lsst.activator.middleware_interface"
 

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -69,6 +69,7 @@ class RawBase:
             dome=FannedOutVisit.Dome.OPEN,
             duration=35.0,
             totalCheckpoints=1,
+            private_sndStamp=1_674_516_794.0,
         )
 
     def test_snap(self):

--- a/tests/test_tester_utils.py
+++ b/tests/test_tester_utils.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import calendar
+import datetime
 import tempfile
 import unittest
 
@@ -31,7 +33,7 @@ import lsst.meas.base
 from lsst.obs.subaru import HyperSuprimeCam
 
 from activator.raw import get_raw_path
-from tester.utils import get_last_group, make_exposure_id
+from tester.utils import get_last_group, make_exposure_id, day_obs_to_unix_utc
 
 
 class TesterUtilsTest(unittest.TestCase):
@@ -112,3 +114,19 @@ class TesterUtilsTest(unittest.TestCase):
         self.assertEqual(exp_id, 21309999)
         with self.assertRaises(RuntimeError):
             make_exposure_id("HSC", 2024100100000, 0)
+
+
+class TesterDateHandlingTest(unittest.TestCase):
+    def _check_day_obs(self, year, month, day):
+        midnight = datetime.datetime(year, month, day, 4, 0, 0, tzinfo=datetime.timezone.utc) \
+            + datetime.timedelta(days=1)  # At midnight, day_obs is the previous day
+        day_obs = int(f"{year}{month:02d}{day:02d}")
+        self.assertAlmostEqual(day_obs_to_unix_utc(day_obs), calendar.timegm(midnight.utctimetuple()))
+
+    def test_day_obs_to_unit_utc(self):
+        for (y, m, d) in [(2023, 8, 9),
+                          (2025, 4, 30),
+                          (1998, 12, 31),
+                          (2000, 1, 1),
+                          ]:
+            self._check_day_obs(y, m, d)

--- a/tests/test_visit.py
+++ b/tests/test_visit.py
@@ -48,6 +48,7 @@ class FannedOutVisitTest(unittest.TestCase):
             dome=FannedOutVisit.Dome.OPEN,
             duration=35.0,
             totalCheckpoints=1,
+            private_sndStamp=1_674_516_794.0,
         )
 
     def test_hash(self):
@@ -99,6 +100,7 @@ class BareVisitTest(unittest.TestCase):
         self.fannedOutVisit = FannedOutVisit(
             instrument="NotACam",
             detector=42,
+            private_sndStamp=1_674_516_794.0,
             **visit_info
         )
 


### PR DESCRIPTION
This PR adds a `private_sndStamp` member to `FannedOutVisit`, and modifies the uploaders to populate it based on the exposure time. This is a breaking change to `FannedOutVisit`, and must be merged alongside lsst-dm/next_visit_fan_out#1.