### PR TITLE
DM-35828: Use MDC or equivalent in prompt_prototype logging

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -288,7 +288,7 @@ def next_visit_handler() -> Tuple[str, int]:
                     mwi.ingest_image(oid)
                     expid_set.add(exp_id)
 
-            _log.debug(f"Waiting for snaps from {expected_visit}.")
+            _log.debug("Waiting for snaps...")
             start = time.time()
             while len(expid_set) < expected_snaps:
                 if startup_response:
@@ -300,11 +300,10 @@ def next_visit_handler() -> Tuple[str, int]:
                 response = []
                 if len(messages) == 0:
                     if end - start < timeout and not startup_response:
-                        _log.debug(f"Empty consume after {end - start}s for {expected_visit}.")
+                        _log.debug(f"Empty consume after {end - start}s.")
                         continue
                     _log.warning(
-                        f"Timed out waiting for image in {expected_visit} "
-                        f"after receiving exposures {expid_set}"
+                        f"Timed out waiting for image after receiving exposures {expid_set}."
                     )
                     break
                 startup_response = []
@@ -336,7 +335,7 @@ def next_visit_handler() -> Tuple[str, int]:
                     # If nimages == 0, any positive number of snaps is OK.
                     if len(expid_set) < expected_visit.nimages:
                         _log.warning(f"Processing {len(expid_set)} snaps, expected {expected_visit.nimages}.")
-                    _log.info(f"Running pipeline on {expected_visit}.")
+                    _log.info("Running pipeline...")
                     try:
                         mwi.run_pipeline(expid_set)
                         # TODO: broadcast alerts here
@@ -347,7 +346,7 @@ def next_visit_handler() -> Tuple[str, int]:
                         mwi.clean_local_repo(expid_set)
                     return "Pipeline executed", 200
             else:
-                _log.error(f"Timed out waiting for images for {expected_visit}.")
+                _log.error("Timed out waiting for images.")
                 return "Timed out waiting for images", 500
     finally:
         consumer.unsubscribe()

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -279,7 +279,7 @@ def next_visit_handler() -> Tuple[str, int]:
             )
             if oid:
                 exp_id = get_exp_id_from_oid(oid)
-                _log.debug("Found %r already present", exp_id)
+                _log.debug("Found exposure %r already present", exp_id)
                 mwi.ingest_image(oid)
                 expid_set.add(exp_id)
 

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -19,11 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["GCloudStructuredLogFormatter", "setup_google_logger", "setup_usdf_logger"]
+__all__ = ["GCloudStructuredLogFormatter", "setup_google_logger", "setup_usdf_logger",
+           "RecordFactoryContextAdapter"]
 
+from contextlib import contextmanager
 import json
 import logging
 import os
+import threading
 
 import lsst.daf.butler as daf_butler
 
@@ -159,3 +162,89 @@ class GCloudStructuredLogFormatter(logging.Formatter):
             "message": record.getMessage(),
         }
         return json.dumps(entry)
+
+
+class RecordFactoryContextAdapter:
+    """A log record factory that adds contextual data to another factory.
+
+    This factory adds a ``logging_context`` mapping to the log record. The
+    mapping is empty by default, and can be managed with the `add_context`
+    context manager. Formatters that can handle the contents of this field
+    must be configured separately.
+
+    Parameters
+    ----------
+    factory : callable
+        A log record factory (satisfying the interface described under
+        `logging.setLogRecordFactory`) to which to add context.
+
+    Notes
+    -----
+    This class is designed to be passed to `logging.setLogRecordFactory`, and
+    therefore be shared among all threads of an application. However, all
+    context is held in thread-local state, so the class is thread-safe in the
+    sense that most application code can act as if each thread had its own
+    factory object.
+    """
+    def __init__(self, factory):
+        self._old_factory = factory
+        # Record factories must be shared to be useful; keep all nontrivial
+        # state in a `local` object to emulate a thread-specific factory.
+        self._store = threading.local()
+        self._store.context = {}
+
+    def __call__(self, *args, **kwargs):
+        """Create a log record from the provided arguments.
+
+        See `logging.setLogRecordFactory` for the parameters.
+
+        Returns
+        -------
+        record : `logging.LogRecord`
+            A log record containing a ``logging_context`` mapping. The mapping
+            maps strings to arbitrary values, as determined by any enclosing
+            calls to `add_context`.
+        """
+        record = self._old_factory(*args, **kwargs)
+        # _store.context is mutable; make sure record can't be changed after the fact.
+        record.logging_context = self._store.context.copy()
+        return record
+
+    @contextmanager
+    def add_context(self, **context):
+        """A context manager that adds contextual data to all logging calls
+        inside it.
+
+        This manager adds key-value pairs to the ``logging_context`` mapping in
+        this factory's log records.
+
+        Parameters
+        ----------
+        context
+            The keys and values to be added to ``logging_context``.
+
+        Notes
+        -----
+        This method is thread-safe (``logging_context`` is thread-confined,
+        even if ``self`` is shared).
+
+        Examples
+        --------
+        >>> import logging, sys
+        >>> logging.basicConfig(stream=sys.stdout,
+        ...                     format="%(logging_context)s: %(levelname)s: %(message)s")
+        >>> # The following line is not thread-safe, for simplicity.
+        >>> logging.setLogRecordFactory(RecordFactoryContextAdapter(logging.getLogRecordFactory()))
+        >>> with logging.getLogRecordFactory().add_context(visit=101, detector=42):
+        ...     logging.error("Does not compute!")
+        {'visit': 101, 'detector': 42}: ERROR: Does not compute!
+        """
+        _old_context = self._store.context.copy()
+        try:
+            self._store.context.update(**context)
+            yield
+        finally:
+            # This replacement is safe because self._store cannot have been
+            # changed by other threads. Changes can only have been made by
+            # nested context managers, which have already been rolled back.
+            self._store.context = _old_context

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -144,7 +144,7 @@ def setup_usdf_logger(labels=None):
     """
     _set_context_logger()
     log_handler = logging.StreamHandler()
-    log_handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(logging_context)s:%(message)s"))
+    log_handler.setFormatter(UsdfJsonFormatter(labels))
     logging.basicConfig(handlers=[log_handler])
     _channel_all_to_pylog()
     _set_lsst_logging_levels()

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -780,8 +780,7 @@ class MiddlewareInterface:
             executor.pre_execute_qgraph(qgraph, register_dataset_types=True, save_init_outputs=True)
             _log.info(f"Running '{pipeline._pipelineIR.description}' on {where}")
             executor.run_pipeline(qgraph)
-            _log.info(f"Pipeline successfully run on "
-                      f"detector {self.visit.detector} of {exposure_ids}.")
+            _log.info("Pipeline successfully run.")
             break
         else:
             # TODO: a good place for a custom exception?
@@ -809,8 +808,7 @@ class MiddlewareInterface:
                                           )
             if exports:
                 exported = True
-                _log.info(f"Pipeline products saved to collection '{output_run}' for "
-                          f"detector {self.visit.detector} of {exposure_ids}.")
+                _log.info(f"Pipeline products saved to collection '{output_run}'.")
         if not exported:
             raise ValueError(f"No datasets match visit={self.visit} and exposures={exposure_ids}.")
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -156,6 +156,34 @@ class GoogleFormatterTest(unittest.TestCase):
         self.assertEqual(len(shredded), 1)
         self.assertIn("Traceback (most recent call last)", shredded[0])
 
+    def test_context(self):
+        """Test handling of messages that have free-form context.
+        """
+        msg = "Consider a spherical exposure."
+        exposures = {1, 2, 3}
+        visit = 42
+        ratio = 3.5
+        group = "group A"
+        settings = {"option": True}
+        with logging.getLogRecordFactory().add_context(
+            exposures=exposures,
+            visit=visit,
+            ratio=ratio,
+            group=group,
+            settings=settings,
+        ):
+            self.log.info(msg)
+        self._check_log(self.output.getvalue().splitlines(),
+                        "INFO",
+                        {"instrument": "NotACam",
+                         "exposures": list(exposures),
+                         "visit": visit,
+                         "ratio": ratio,
+                         "group": group,
+                         "settings": settings,
+                         },
+                        [msg])
+
     def test_side_effects(self):
         """Test that format still modifies exposure records in the same way
         as Formatter.format.
@@ -277,6 +305,34 @@ class UsdfJsonFormatterTest(unittest.TestCase):
         shredded = self.output.getvalue().splitlines()
         self.assertEqual(len(shredded), 1)
         self.assertIn("Traceback (most recent call last)", shredded[0])
+
+    def test_context(self):
+        """Test handling of messages that have free-form context.
+        """
+        msg = "Consider a spherical exposure."
+        exposures = {1, 2, 3}
+        visit = 42
+        ratio = 3.5
+        group = "group A"
+        settings = {"option": True}
+        with logging.getLogRecordFactory().add_context(
+            exposures=exposures,
+            visit=visit,
+            ratio=ratio,
+            group=group,
+            settings=settings,
+        ):
+            self.log.info(msg)
+        self._check_log(self.output.getvalue().splitlines(),
+                        "test_context", "INFO",
+                        {"instrument": "NotACam",
+                         "exposures": list(exposures),
+                         "visit": visit,
+                         "ratio": ratio,
+                         "group": group,
+                         "settings": settings,
+                         },
+                        [msg])
 
     def test_side_effects(self):
         """Test that format still modifies exposure records in the same way

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -65,6 +65,11 @@ class GoogleFormatterTest(unittest.TestCase):
         self.output = io.StringIO()
         self.addCleanup(io.StringIO.close, self.output)
 
+        # GCloudStructuredLogFormatter assumes a logging_context field is present.
+        old_factory = logging.getLogRecordFactory()
+        self.addCleanup(logging.setLogRecordFactory, old_factory)
+        logging.setLogRecordFactory(RecordFactoryContextAdapter(old_factory))
+
         log_handler = logging.StreamHandler(self.output)
         log_handler.setFormatter(GCloudStructuredLogFormatter(
             labels={"instrument": "NotACam"},

--- a/ups/prompt_prototype.table
+++ b/ups/prompt_prototype.table
@@ -6,10 +6,11 @@ setupRequired(base)
 setupRequired(sconsUtils)
 setupRequired(utils)         # Used by scripts in bin.src
 
-# Used by middleware_interface module due to hard-coded pipeline references.
+# Used by pipelines
 setupRequired(ap_pipe)
-# Borrow LATISS configs from drp_pipe
-setupRequired(drp_pipe)
+setupRequired(obs_lsst)
+
+# Used by middleware_interface
 setupRequired(daf_butler)
 setupRequired(ctrl_mpexec)
 setupRequired(geom)


### PR DESCRIPTION
This PR adds a context manager that allows all logging statements (including those from other packages) to be decorated with metadata about the visit-detector being processed. It also adds a JSON-based log formatter that makes it easier for Grafana queries to take advantage of the extra information.