### PR TITLE
DM-38215: Parallelize upload_hsc_rc2.py

### DIFF
--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -66,6 +66,9 @@ def process_group(kafka_url, visit_infos, uploader):
         _log.info("No observations to make; aborting.")
         return
 
+    _log.info(f"Slewing to group {group}")
+    time.sleep(SLEW_INTERVAL)
+
     # TODO: need asynchronous code to handle next_visit delay correctly
     for snap in range(n_snaps):
         _log.info(f"Taking group: {group} snap: {snap}")
@@ -257,7 +260,6 @@ def upload_from_raws(kafka_url, instrument, raw_pool, src_bucket, dest_bucket, n
                 dest_bucket.upload_fileobj(buffer, filename)
 
         process_group(kafka_url, visit_infos, upload_from_pool)
-        time.sleep(SLEW_INTERVAL)
 
 
 if __name__ == "__main__":

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -99,9 +99,9 @@ def main():
             tempfile.TemporaryDirectory() as temp_dir:
         for visit in visit_list:
             group_num += 1
+            refs = prepare_one_visit(kafka_url, str(group_num), butler, visit)
             _log.info(f"Slewing to group {group_num}, with HSC visit {visit}")
             time.sleep(SLEW_INTERVAL)
-            refs = prepare_one_visit(kafka_url, str(group_num), butler, visit)
             _log.info(f"Taking exposure for group {group_num}")
             time.sleep(EXPOSURE_INTERVAL)
             _log.info(f"Uploading detector images for group {group_num}")

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -166,7 +166,7 @@ def upload_hsc_images(dest_bucket, group_id, butler, refs):
 
     Parameters
     ----------
-    dest_bucket: `S3.Bucket`
+    dest_bucket : `S3.Bucket`
         The bucket to which to upload the images.
     group_id : `str`
         The group ID under which to store the images.

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -91,7 +91,9 @@ def main():
     # for Butler registry or S3.
     context = multiprocessing.get_context("spawn")
     max_processes = _get_max_processes()
-    # Use a shared pool to minimize initialization overhead.
+    # Use a shared pool to minimize initialization overhead. This has the
+    # benefit of letting the pool be initialized in parallel with the first
+    # exposure.
     _log.debug("Uploading with %d processes...", max_processes)
     with context.Pool(processes=max_processes, initializer=_set_s3_bucket) as pool:
         for visit in visit_list:
@@ -205,7 +207,7 @@ def upload_hsc_images(pool, group_id, butler, refs):
         with time_this(log=_log, msg="Full visit processing", prefix=None):
             pool.starmap(_upload_one_image,
                          [(temp_dir, group_id, butler, ref) for ref in refs],
-                         chunksize=10
+                         chunksize=5  # Works well across a broad range of # processes
                          )
 
 

--- a/python/tester/upload_hsc_rc2.py
+++ b/python/tester/upload_hsc_rc2.py
@@ -189,10 +189,7 @@ def upload_hsc_images(group_id, butler, refs):
     refs : iterable of `lsst.daf.butler.DatasetRef`
         The datasets to upload
     """
-    try:
-        max_processes = math.ceil(0.25*multiprocessing.cpu_count())
-    except NotImplementedError:
-        max_processes = 4
+    max_processes = _get_max_processes()
 
     with tempfile.TemporaryDirectory() as temp_dir:
         # fork pools don't work well with connection pools, such as those used
@@ -204,6 +201,21 @@ def upload_hsc_images(group_id, butler, refs):
                          [(temp_dir, group_id, butler, ref) for ref in refs],
                          chunksize=10
                          )
+
+
+def _get_max_processes():
+    """Return the optimal process limit.
+
+    Returns
+    -------
+    processes : `int`
+        The maximum number of processes that balances system usage, pool
+        overhead, and processing speed.
+    """
+    try:
+        return math.ceil(0.25*multiprocessing.cpu_count())
+    except NotImplementedError:
+        return 4
 
 
 def _upload_one_image(temp_dir, group_id, butler, ref):


### PR DESCRIPTION
This PR reorganizes the raw file upload in `uplaod_hsc_rc2.py` to use a process pool that runs in parallel with the main "exposure-taking" thread. The result is that I/O is no longer a bottleneck for this program; it now runs in the time needed to perform the virtual slew and exposure operations (plus a few seconds for the last visit's upload).