### PR TITLE
DM-40163: Rework dataset transfer code in MiddlewareInterface

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -381,6 +381,7 @@ class MiddlewareInterface:
                 self._export_refcats(export, center, radius)
                 self._export_skymap_and_templates(export, center, detector, wcs, self.visit.filters)
                 self._export_calibs(export, self.visit.detector, self.visit.filters)
+                self._export_collections(export, self._get_template_collection())
                 self._export_collections(export, self.instrument.makeUmbrellaCollectionName())
 
             self.butler.import_(filename=export_file.name,
@@ -486,7 +487,6 @@ class MiddlewareInterface:
         else:
             _log.debug("Found %d new template datasets.", len(templates))
             export.saveDatasets(templates)
-        self._export_collections(export, self._get_template_collection())
 
     def _export_calibs(self, export, detector_id, filter):
         """Export the calibs for this visit from the central butler.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -921,8 +921,11 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.processed_data_id = {(k if k != "exposure" else "visit"): v for k, v in self.raw_data_id.items()}
         self.second_processed_data_id = {(k if k != "exposure" else "visit"): v
                                          for k, v in self.second_data_id.items()}
-        # Dataset types defined for local Butler on pipeline run, but no
-        # guarantee this happens in central Butler.
+        # Dataset types defined for local Butler on pipeline run, but code
+        # assumes output types already exist in central repo.
+        butler_tests.addDatasetType(self.interface.central_butler, "calexp",
+                                    {"instrument", "visit", "detector"},
+                                    "ExposureF")
         butler_tests.addDatasetType(self.interface.butler, "calexp",
                                     {"instrument", "visit", "detector"},
                                     "ExposureF")


### PR DESCRIPTION
This PR removes the export/import idiom from MiddlewareInterface. The old idiom needed to use the deprecated `butler.datastore.root` to anchor relative paths, and there's no guarantee that the central repo won't have its datasets split among multiple stores.