### PR TITLE
DM-41084: AttributeError: '_thread._local' object has no attribute 'context'

### DIFF
--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -278,7 +278,6 @@ class RecordFactoryContextAdapter:
         # Record factories must be shared to be useful; keep all nontrivial
         # state in a `local` object to emulate a thread-specific factory.
         self._store = threading.local()
-        self._context = {}
 
     @property
     def _context(self):
@@ -287,7 +286,10 @@ class RecordFactoryContextAdapter:
 
         This value is guaranteed to be thread confined.
         """
-        # This property MUST NOT be called before self._store is initialized.
+        # Cannot initialize self._store.context in a way that's visible to all
+        # threads, so handle initialization lazily instead.
+        if not hasattr(self._store, "context"):
+            self._store.context = {}
         return self._store.context
 
     @_context.setter

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -278,7 +278,21 @@ class RecordFactoryContextAdapter:
         # Record factories must be shared to be useful; keep all nontrivial
         # state in a `local` object to emulate a thread-specific factory.
         self._store = threading.local()
-        self._store.context = {}
+        self._context = {}
+
+    @property
+    def _context(self):
+        """The values to add to ``logging_context`` at any given time
+        (mutable mapping).
+
+        This value is guaranteed to be thread confined.
+        """
+        # This property MUST NOT be called before self._store is initialized.
+        return self._store.context
+
+    @_context.setter
+    def _context(self, value):
+        self._store.context = value
 
     def __call__(self, *args, **kwargs):
         """Create a log record from the provided arguments.
@@ -293,8 +307,8 @@ class RecordFactoryContextAdapter:
             calls to `add_context`.
         """
         record = self._old_factory(*args, **kwargs)
-        # _store.context is mutable; make sure record can't be changed after the fact.
-        record.logging_context = self._store.context.copy()
+        # _context is mutable; make sure record can't be changed after the fact.
+        record.logging_context = self._context.copy()
         return record
 
     @contextmanager
@@ -326,12 +340,12 @@ class RecordFactoryContextAdapter:
         ...     logging.error("Does not compute!")
         {'visit': 101, 'detector': 42}: ERROR: Does not compute!
         """
-        _old_context = self._store.context.copy()
+        _old_context = self._context.copy()
         try:
-            self._store.context.update(**context)
+            self._context.update(**context)
             yield
         finally:
-            # This replacement is safe because self._store cannot have been
+            # This replacement is safe because self._context cannot have been
             # changed by other threads. Changes can only have been made by
             # nested context managers, which have already been rolled back.
-            self._store.context = _old_context
+            self._context = _old_context


### PR DESCRIPTION
This PR defers initialization of `RecordFactoryContextAdapter._store.context` to ensure that each thread sees the correct initial state (an empty mapping). This prevents a bug where attempts to log from any thread other than the main one raised an `AttributeError`.