### PR TITLE
DM-41658: Prompt Processing can't configure surveys with "-"

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -160,7 +160,9 @@ def parse_next_visit(http_request):
 
     # Message format is determined by the nextvisit-start deployment.
     data = json.loads(event.data)
-    return FannedOutVisit(**data)
+    visit = FannedOutVisit(**data)
+    _log.debug("Unpacked message as %r.", visit)
+    return visit
 
 
 def _filter_messages(messages):

--- a/python/activator/config.py
+++ b/python/activator/config.py
@@ -122,7 +122,7 @@ class PipelinesConfig:
         # when the input is invalid. If pickier matching is needed in the
         # future, use a separate regex for filelist instead of making node
         # more complex.
-        node = re.compile(r'\s*\(survey="(?P<survey>[\w\s]*)"\)='
+        node = re.compile(r'\s*\(survey="(?P<survey>[^"\n=]*)"\)='
                           r'(?:\[(?P<filelist>[^]]*)\]|none)(?:\s+|$)',
                           re.IGNORECASE)
 

--- a/python/activator/config.py
+++ b/python/activator/config.py
@@ -130,9 +130,13 @@ class PipelinesConfig:
         pos = 0
         match = node.match(config, pos)
         while match:
-            if match['filelist'] is not None:
-                filenames = [file.strip() for file in match['filelist'].split(',')] \
-                    if match['filelist'] else []
+            if match['filelist']:  # exclude None and ""; latter gives unexpected behavior with split
+                filenames = []
+                for file in match['filelist'].split(','):
+                    file = file.strip()
+                    if "\n" in file:
+                        raise ValueError(f"Unexpected newline in '{file}'.")
+                    filenames.append(file)
                 items[match['survey']] = filenames
             else:
                 items[match['survey']] = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,6 +119,24 @@ class PipelinesConfigTest(unittest.TestCase):
             [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipe lines", "Isr.yaml"))]
         )
 
+    def test_extrachars(self):
+        config = PipelinesConfig('(survey="stylish-modern-survey")=[/etc/pipelines/SingleFrame.yaml] '
+                                 '(survey="ScriptParams4,6")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
+                                 '(survey="slash/and\backslash")=[Default.yaml] '
+                                 )
+        self.assertEqual(
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="stylish-modern-survey")),
+            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
+        )
+        self.assertEqual(
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="ScriptParams4,6")),
+            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
+        )
+        self.assertEqual(
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey="slash/and\backslash")),
+            ["Default.yaml"]
+        )
+
     def test_none(self):
         config = PipelinesConfig('(survey="TestSurvey")=[None shall pass/pipelines/SingleFrame.yaml] '
                                  '(survey="Camera Test")=None '

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,6 +174,16 @@ class PipelinesConfigTest(unittest.TestCase):
                             '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
                             )
 
+    def test_bad_line_breaks(self):
+        with self.assertRaises(ValueError):
+            PipelinesConfig('''(survey="Test
+                               Survey")=[/etc/pipelines/SingleFrame.yaml]'''
+                            )
+        with self.assertRaises(ValueError):
+            PipelinesConfig('''(survey="TestSurvey")=[/etc/pipelines/
+                                                      SingleFrame.yaml]'''
+                            )
+
     def test_unlabeled(self):
         with self.assertRaises(ValueError):
             PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml], '


### PR DESCRIPTION
This PR makes the pipeline config parsing more flexible regarding survey names, now allowing any character that isn't clearly problematic.